### PR TITLE
Set rich traceback `show_locals` to `False`

### DIFF
--- a/src/pyvisgen/__init__.py
+++ b/src/pyvisgen/__init__.py
@@ -11,4 +11,4 @@ from .version import __version__
 __all__ = ["__version__"]
 
 
-install(show_locals=True)
+install(show_locals=False)


### PR DESCRIPTION
Removes output of local variables from tracebacks.