### PR TITLE
Add Data Format Converter

### DIFF
--- a/docs/api-reference/io/dataconverter.rst
+++ b/docs/api-reference/io/dataconverter.rst
@@ -1,0 +1,17 @@
+.. _dataconverter:
+
+********************************************************
+Data Format Converter (:mod:`pyvisgen.io.dataconverter`)
+********************************************************
+
+.. currentmodule:: pyvisgen.io.dataconverter
+
+Data format converter submodule of :mod:`pyvisgen.io`. The data format converter allows
+converting from one format to a different one. The formats have to be compatible
+with existing formats of ``pyvisgen``, i.e. those that are created with :ref:`datawriters`.
+
+Reference/API
+=============
+
+.. automodapi:: pyvisgen.io.dataconverter
+    :inherited-members:

--- a/docs/api-reference/io/index.rst
+++ b/docs/api-reference/io/index.rst
@@ -22,6 +22,7 @@ Submodules
 
   config
   datawriters
+  dataconverter
 
 
 Reference/API

--- a/docs/changes/132.bugfix.rst
+++ b/docs/changes/132.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the output file name and included objects of :class:`~pyvisgen.io.PTWriter`

--- a/docs/changes/132.feature.rst
+++ b/docs/changes/132.feature.rst
@@ -1,0 +1,3 @@
+Added data format converter (:class:`pyvisgen.io.DataConverter`) that enables fast conversion between HDF5, WebDatset, and PyTorch files
+
+Added CLI tool (``$ pyvisgen convert``) for the new data format converter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ omit = [
   "src/pyvisgen/_version.py",
   "src/pyvisgen/gridding/alt_gridder.py",
   "src/pyvisgen/version.py",
+  "tests/*"
 ]
 
 [tool.coverage.xml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,8 @@ exclude_also = [
   "raise NotImplementedError",
   "if __name__ == .__main__.:",
   "if TYPE_CHECKING:",
+  "if not _WDS_AVAIL:",
+  "try:(?s:.)*?except ImportError:",
 ]
 
 [tool.hatch.version]

--- a/src/pyvisgen/dataset/dataset.py
+++ b/src/pyvisgen/dataset/dataset.py
@@ -146,15 +146,7 @@ class SimulateDataSet:
             f"Simulating {cls.conf.bundle.dataset_type} dataset", total=3
         )
 
-        with (
-            Live(progress_group),
-            cls.conf.datawriter.writer(
-                output_path=cls.out_path,
-                dataset_type=cls.conf.bundle.dataset_type,
-                amp_phase=cls.conf.bundle.amp_phase,
-                **cls.conf.datawriter.model_dump(),
-            ) as cls.writer,
-        ):
+        with Live(progress_group):
             if cls.num_images is None:
                 # get number of random parameter draws from number of images in data
                 counting_task_id = counting_progress.add_task(

--- a/src/pyvisgen/io/__init__.py
+++ b/src/pyvisgen/io/__init__.py
@@ -1,4 +1,12 @@
 from .config import Config
+from .dataconverter import DataConverter
 from .datawriters import FITSWriter, H5Writer, PTWriter, WDSShardWriter
 
-__all__ = ["Config", "H5Writer", "FITSWriter", "PTWriter", "WDSShardWriter"]
+__all__ = [
+    "Config",
+    "H5Writer",
+    "FITSWriter",
+    "PTWriter",
+    "WDSShardWriter",
+    "DataConverter",
+]

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -32,13 +32,13 @@ class DataConverter:
 
         data_dir = Path(data_dir).expanduser().resolve()
 
-        cls.datasets = {dataset_type: data_dir.glob(f"{dataset_type}-*.tar*")}
-        if dataset_type == "all":
-            cls.datasets = {
-                "train": data_dir.glob("train-*.tar*"),
-                "valid": data_dir.glob("valid-*.tar*"),
-                "test": data_dir.glob("test-*.tar*"),
-            }
+        if not isinstance(dataset_type, list):
+            dataset_type = [dataset_type]
+
+        if "all" in dataset_type:
+            dataset_type = ["train", "valid", "test"]
+
+        cls.datasets = {t: data_dir.glob(f"{t}-*.tar*") for t in dataset_type}
 
         return cls
 
@@ -49,13 +49,13 @@ class DataConverter:
 
         data_dir = Path(data_dir).expanduser().resolve()
 
-        cls.datasets = {dataset_type: data_dir.glob(f"*{dataset_type}_*.h5")}
-        if dataset_type == "all":
-            cls.datasets = {
-                "train": data_dir.glob("*train_*.h5"),
-                "valid": data_dir.glob("*valid_*.h5"),
-                "test": data_dir.glob("*test_*.h5"),
-            }
+        if not isinstance(dataset_type, list):
+            dataset_type = [dataset_type]
+
+        if "all" in dataset_type:
+            dataset_type = ["train", "valid", "test"]
+
+        cls.datasets = {t: data_dir.glob(f"*{dataset_type}_*.h5") for t in dataset_type}
 
         return cls
 

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -30,12 +30,14 @@ class DataConverter:
         cls = cls()
         cls._FMT = "wds"
 
-        cls.datasets = {dataset_type: Path(data_dir).glob(f"{dataset_type}-*.tar*")}
+        data_dir = Path(data_dir).expanduser().resolve()
+
+        cls.datasets = {dataset_type: data_dir.glob(f"{dataset_type}-*.tar*")}
         if dataset_type == "all":
             cls.datasets = {
-                "train": Path(data_dir).glob("train-*.tar*"),
-                "valid": Path(data_dir).glob("valid-*.tar*"),
-                "test": Path(data_dir).glob("test-*.tar*"),
+                "train": data_dir.glob("train-*.tar*"),
+                "valid": data_dir.glob("valid-*.tar*"),
+                "test": data_dir.glob("test-*.tar*"),
             }
 
         return cls
@@ -45,12 +47,14 @@ class DataConverter:
         cls = cls()
         cls._FMT = "h5"
 
-        cls.datasets = {dataset_type: Path(data_dir).glob(f"*{dataset_type}_*.h5")}
+        data_dir = Path(data_dir).expanduser().resolve()
+
+        cls.datasets = {dataset_type: data_dir.glob(f"*{dataset_type}_*.h5")}
         if dataset_type == "all":
             cls.datasets = {
-                "train": Path(data_dir).glob("*train_*.h5"),
-                "valid": Path(data_dir).glob("*valid_*.h5"),
-                "test": Path(data_dir).glob("*test_*.h5"),
+                "train": data_dir.glob("*train_*.h5"),
+                "valid": data_dir.glob("*valid_*.h5"),
+                "test": data_dir.glob("*test_*.h5"),
             }
 
         return cls
@@ -141,7 +145,7 @@ class DataConverter:
         shard_pattern="%06d.tar",
         amp_phase=True,
     ):
-        self.output_dir = Path(output_dir)
+        self.output_dir = Path(output_dir).expanduser().resolve()
         if not self.output_dir.is_dir():
             self.output_dir.mkdir(parents=True)
 

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -153,7 +153,35 @@ class DataConverter:
 
     @classmethod
     def from_pt(cls, data_dir, dataset_type="all"):
-        raise NotImplementedError("PT will be supported in a future release.")
+        """Create a DataConverter instance from HDF5 files.
+
+        Parameters
+        ----------
+        data_dir : str or :class:`~pathlib.Path`
+            Directory containing .pt files.
+        dataset_type :  str or list
+            Dataset split to load.  If "all", loads train, valid, and test.
+            Default: ``"all"``
+
+        Returns
+        -------
+        DataConverter
+            Configured DataConverter instance with PyTorch pickle source files.
+        """
+        cls = cls()
+        cls._FMT = "pt"
+
+        data_dir = Path(data_dir).expanduser().resolve()
+
+        if not isinstance(dataset_type, list):
+            dataset_type = [dataset_type]
+
+        if "all" in dataset_type:
+            dataset_type = ["train", "valid", "test"]
+
+        cls.datasets = {t: data_dir.glob(f"*{dataset_type}_*.pt") for t in dataset_type}
+
+        return cls
 
     def _to_h5(self) -> None:
         """Internal method to handle conversion to HDF5 files."""
@@ -275,6 +303,7 @@ class DataConverter:
                         pa.parquet.write_table(table, file)
 
     def _to_pt(self):
+        """Internal method to handle conversion to PT files."""
         if self._FMT == "wds":
             for dataset_type, files in track(
                 self.datasets.items(), description="Converting Dataset to PT"

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -116,7 +116,6 @@ class DataConverter:
                     half_image=False,
                 ) as writer:
                     for file in track(list(files), description="Processing files..."):
-                        print(file)
                         data = h5py.File(file)
                         file_idx = re.findall(r"\d+", file.stem)
 

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -236,8 +236,8 @@ class DataConverter:
                     output_path=self.output_dir,
                     dataset_type=dataset_type,
                     total_samples=total_samples,
-                    shard_pattern=self.shard_pattern,
                     amp_phase=self.amp_phase,
+                    shard_pattern=self.shard_pattern,
                     compress=self.compress,
                     half_image=False,
                 ) as writer:
@@ -362,7 +362,7 @@ class DataConverter:
             x_data = np.asarray(x_data)
             y_data = np.asarray(y_data)
 
-            writer.write(x_data, y_data, index=file_idx, bundle_length=len(x_data))
+            writer.write(x_data, y_data, index=int(file_idx), bundle_length=len(x_data))
 
     def to(
         self,

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -182,7 +182,7 @@ class DataConverter:
         """Internal method to handle conversion to HDF5 files."""
         if self._FMT == "wds":
             for dataset_type, files in track(
-                self.datasets.items(), description="Converting Dataset to PT"
+                self.datasets.items(), description="Converting Dataset to HDF5"
             ):
                 with H5Writer(
                     output_path=self.output_dir,
@@ -192,7 +192,7 @@ class DataConverter:
                     self._handle_wds(files, writer)
         elif self._FMT == "pt":
             for dataset_type, files in track(
-                self.datasets.items(), description="Converting Dataset to PT"
+                self.datasets.items(), description="Converting Dataset to HDF5"
             ):
                 with H5Writer(
                     output_path=self.output_dir,
@@ -225,7 +225,7 @@ class DataConverter:
         """Internal method to handle conversion to WebDataset files."""
         if self._FMT == "h5":
             for dataset_type, files in track(
-                self.datasets.items(), description="Converting Dataset to HDF5"
+                self.datasets.items(), description="Converting Dataset to WDS"
             ):
                 # total_samples is updated after writing all files
                 total_samples = 0
@@ -254,13 +254,17 @@ class DataConverter:
 
         elif self._FMT == "pt":
             amp_phase = None
+
+            # total_samples is updated after writing all files
+            total_samples = 0
             for dataset_type, files in track(
-                self.datasets.items(), description="Converting Dataset to PT"
+                self.datasets.items(), description="Converting Dataset to WDS"
             ):
                 with WDSShardWriter(
                     output_path=self.output_dir,
                     dataset_type=dataset_type,
                     total_samples=total_samples,
+                    amp_phase=self.amp_phase,
                     shard_pattern=self.shard_pattern,
                     compress=self.compress,
                     half_image=False,

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyarrow as pa
 from rich.progress import track
 
-from pyvisgen.io import H5Writer, WDSShardWriter
+from .datawriters import H5Writer, WDSShardWriter
 
 try:
     import pyarrow as pa

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -49,7 +49,8 @@ def _batch_array(
     indices = np.arange(batch_size, len(array), batch_size)
 
     if return_indices:
-        return np.split(array, indices), indices
+        # also include zero when returning indices
+        return np.split(array, indices), np.insert(indices, 0, 0)
 
     return np.split(array, indices)
 
@@ -66,12 +67,12 @@ class DataConverter:
     --------
     Convert WebDataset to HDF5:
 
-    >>> converter = DataConverter.from_wds("~/data/visibilities")
-    >>> converter.to("~/data/output", output_format="h5")
+    >>> converter = DataConverter.from_wds("./data/visibilities")
+    >>> converter.to("./data/output", output_format="h5")
 
     Convert HDF5 train split to WebDataset:
 
-    >>> converter = DataConverter.from_h5("~/data/visibilities", dataset_type="train")
+    >>> converter = DataConverter.from_h5("./data/visibilities", dataset_type="train")
     >>> converter.to("~/data/output", output_format="wds", compress=True)
     """
 

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -332,11 +332,14 @@ class DataConverter:
                         data = h5py.File(file)
                         file_idx = re.findall(r"\d+", file.stem)
 
+                        x = np.asarray(data["x"])
+                        y = np.asarray(data["y"])
+
                         writer.write(
-                            data["x"],
-                            data["y"],
+                            x,
+                            y,
                             index=int(file_idx[0]),
-                            bundle_length=len(data["x"]),
+                            bundle_length=len(x),
                         )
 
     def _handle_wds(self, files, writer):

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -1,0 +1,158 @@
+import re
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pyarrow as pa
+from rich.progress import track
+
+from pyvisgen.io import H5Writer, WDSShardWriter
+
+try:
+    import pyarrow as pa
+    import webdataset as wds
+
+    _WDS_AVAIL = True
+except ImportError:
+    _WDS_AVAIL = False
+
+
+class DataConverter:
+    @classmethod
+    def from_wds(cls, data_dir, dataset_type="all"):
+        if not _WDS_AVAIL:
+            raise ImportError(
+                "Could not import webdataset. Please make sure you install "
+                "pyvisgen with the webdataset extra: "
+                "uv pip install pyvisgen[webdataset]"
+            )
+
+        cls = cls()
+        cls._FMT = "wds"
+
+        cls.datasets = {dataset_type: Path(data_dir).glob(f"{dataset_type}-*.tar*")}
+        if dataset_type == "all":
+            cls.datasets = {
+                "train": Path(data_dir).glob("train-*.tar*"),
+                "valid": Path(data_dir).glob("valid-*.tar*"),
+                "test": Path(data_dir).glob("test-*.tar*"),
+            }
+
+        return cls
+
+    @classmethod
+    def from_h5(cls, data_dir, dataset_type="all"):
+        cls = cls()
+        cls._FMT = "h5"
+
+        cls.datasets = {dataset_type: Path(data_dir).glob(f"*{dataset_type}_*.h5")}
+        if dataset_type == "all":
+            cls.datasets = {
+                "train": Path(data_dir).glob("*train_*.h5"),
+                "valid": Path(data_dir).glob("*valid_*.h5"),
+                "test": Path(data_dir).glob("*test_*.h5"),
+            }
+
+        return cls
+
+    @classmethod
+    def from_pt(cls, data_dir, dataset_type="all"):
+        raise NotImplementedError("PT will be supported in a future release.")
+
+    def _to_h5(self):
+        if self._FMT == "wds":
+            for dataset_type, files in track(
+                self.datasets.items(), description="Converting Dataset to HDF5"
+            ):
+                with H5Writer(
+                    output_path=self.output_dir,
+                    dataset_type=dataset_type,
+                    half_image=False,
+                ) as writer:
+                    for file in track(list(files), description="Processing files..."):
+                        file_idx = re.findall(r"\d+", file.stem)
+                        file_idx = re.sub(r"0+(.+)", r"\1", *file_idx)
+
+                        webdataset = (
+                            wds.WebDataset(str(file), shardshuffle=False)
+                            .decode()
+                            .to_tuple("input.npy", "target.npy")
+                        )
+
+                        x_data = []
+                        y_data = []
+                        for inp, tar in webdataset:
+                            x_data.append(inp)
+                            y_data.append(tar)
+
+                        x_data = np.asarray(x_data)
+                        y_data = np.asarray(y_data)
+
+                        writer.write(x_data, y_data, index=file_idx)
+        elif self._FMT == "pt":
+            raise NotImplementedError("PT will be supported in a future release.")
+        elif self._FMT == "h5":
+            raise RuntimeError("Forbidden: Cannot convert HDF5 to  HDF5.")
+
+    def _to_wds(self):
+        if self._FMT == "h5":
+            for dataset_type, files in track(
+                self.datasets.items(), description="Converting Dataset to HDF5"
+            ):
+                # total_samples is updated after writing all files
+                total_samples = 0
+
+                with WDSShardWriter(
+                    output_path=self.output_dir,
+                    dataset_type=dataset_type,
+                    total_samples=total_samples,
+                    shard_pattern=self.shard_pattern,
+                    amp_phase=self.amp_phase,
+                    compress=self.compress,
+                    half_image=False,
+                ) as writer:
+                    for file in track(list(files), description="Processing files..."):
+                        print(file)
+                        data = h5py.File(file)
+                        file_idx = re.findall(r"\d+", file.stem)
+
+                        writer.write(data["x"], data["y"], index=int(file_idx[0]))
+                        total_samples += len(data["x"])
+
+                    for file in self.output_dir.glob(f"{dataset_type}*.parquet"):
+                        metadata = pa.parquet.read_table(file).to_pandas()
+                        metadata["total_samples_in_dataset"] = total_samples
+                        table = pa.Table.from_pandas(metadata)
+                        pa.parquet.write_table(table, file)
+
+        elif self._FMT == "pt":
+            raise NotImplementedError("PT will be supported in a future release.")
+        elif self._FMT == "wds":
+            raise RuntimeError("Forbidden: Cannot convert WebDataset to WebDataset.")
+
+    def _to_pt(self):
+        pass
+
+    def to(
+        self,
+        output_dir,
+        output_format: str = "h5",
+        compress=True,
+        shard_pattern="%06d.tar",
+        amp_phase=True,
+    ):
+        self.output_dir = Path(output_dir)
+        if not self.output_dir.is_dir():
+            self.output_dir.mkdir(parents=True)
+
+        self.compress = compress
+        self.shard_pattern = shard_pattern
+        self.amp_phase = amp_phase
+
+        match output_format:
+            case "h5":
+                self._to_h5()
+            case "wds":
+                self._to_wds()
+            case "pt":
+                raise NotImplementedError("PT will be supported in a future release.")

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -72,19 +72,19 @@ class DataConverter:
 
     Convert HDF5 train split to WebDataset:
 
-    >>> converter = DataConverter.from_h5("./data/visibilities", dataset_type="train")
+    >>> converter = DataConverter.from_h5("./data/visibilities", dataset_split="train")
     >>> converter.to("~/data/output", output_format="wds", compress=True)
     """
 
     @classmethod
-    def from_wds(cls, data_dir, dataset_type="all") -> Self:
+    def from_wds(cls, data_dir, dataset_split="all") -> Self:
         """Create a DataConverter instance from WebDataset files.
 
         Parameters
         ----------
         data_dir : str or :class:`~pathlib.Path`
             Directory containing WebDataset .tar(.gz) files.
-        dataset_type :  str or list
+        dataset_split :  str or list
             Dataset split to load.  If "all", loads train, valid, and test.
             Default: ``"all"``
 
@@ -109,26 +109,21 @@ class DataConverter:
         cls._FMT = "wds"
 
         data_dir = Path(data_dir).expanduser().resolve()
+        dataset_split = cls._get_dataset_split(dataset_split)
 
-        if not isinstance(dataset_type, list):
-            dataset_type = [dataset_type]
-
-        if "all" in dataset_type:
-            dataset_type = ["train", "valid", "test"]
-
-        cls.datasets = {t: data_dir.glob(f"{t}-*.tar*") for t in dataset_type}
+        cls.datasets = {t: data_dir.glob(f"{t}-*.tar*") for t in dataset_split}
 
         return cls
 
     @classmethod
-    def from_h5(cls, data_dir, dataset_type="all") -> Self:
+    def from_h5(cls, data_dir, dataset_split="all") -> Self:
         """Create a DataConverter instance from HDF5 files.
 
         Parameters
         ----------
         data_dir : str or :class:`~pathlib.Path`
             Directory containing HDF5 files.
-        dataset_type :  str or list
+        dataset_split :  str or list
             Dataset split to load.  If "all", loads train, valid, and test.
             Default: ``"all"``
 
@@ -141,26 +136,21 @@ class DataConverter:
         cls._FMT = "h5"
 
         data_dir = Path(data_dir).expanduser().resolve()
+        dataset_split = cls._get_dataset_split(dataset_split)
 
-        if not isinstance(dataset_type, list):
-            dataset_type = [dataset_type]
-
-        if "all" in dataset_type:
-            dataset_type = ["train", "valid", "test"]
-
-        cls.datasets = {t: data_dir.glob(f"*{dataset_type}_*.h5") for t in dataset_type}
+        cls.datasets = {t: data_dir.glob(f"*{t}_*.h5") for t in dataset_split}
 
         return cls
 
     @classmethod
-    def from_pt(cls, data_dir, dataset_type="all"):
+    def from_pt(cls, data_dir, dataset_split="all"):
         """Create a DataConverter instance from HDF5 files.
 
         Parameters
         ----------
         data_dir : str or :class:`~pathlib.Path`
             Directory containing .pt files.
-        dataset_type :  str or list
+        dataset_split :  str or list
             Dataset split to load.  If "all", loads train, valid, and test.
             Default: ``"all"``
 
@@ -173,16 +163,20 @@ class DataConverter:
         cls._FMT = "pt"
 
         data_dir = Path(data_dir).expanduser().resolve()
+        dataset_split = cls._get_dataset_split(dataset_split)
 
-        if not isinstance(dataset_type, list):
-            dataset_type = [dataset_type]
-
-        if "all" in dataset_type:
-            dataset_type = ["train", "valid", "test"]
-
-        cls.datasets = {t: data_dir.glob(f"*{dataset_type}_*.pt") for t in dataset_type}
+        cls.datasets = {t: data_dir.glob(f"*{t}_*.pt") for t in dataset_split}
 
         return cls
+
+    def _get_dataset_split(self, dataset_split):
+        if not isinstance(dataset_split, list):
+            dataset_split = [dataset_split]
+
+        if "all" in dataset_split:
+            dataset_split = ["train", "valid", "test"]
+
+        return dataset_split
 
     def _to_h5(self) -> None:
         """Internal method to handle conversion to HDF5 files."""

--- a/src/pyvisgen/io/dataconverter.py
+++ b/src/pyvisgen/io/dataconverter.py
@@ -211,14 +211,16 @@ class DataConverter:
                         y = []
                         for file in bundle:
                             data = torch.load(file)
-                            x.append(data["SIM"])
+                            x.append(data["SIM"].to_dense())
                             y.append(data["TRUTH"])
 
+                        x = np.asarray(x)
+                        y = np.asarray(y)
+                        x = np.stack((x.real, x.imag), axis=1)
+                        y = np.stack((y.real, y.imag), axis=1)
+
                         writer.write(
-                            np.asarray(x),
-                            np.asarray(y),
-                            index=int(index),
-                            bundle_length=len(data["SIM"]),
+                            x, y, index=int(index), bundle_length=len(data["SIM"])
                         )
 
     def _to_wds(self) -> None:
@@ -281,16 +283,18 @@ class DataConverter:
                         y = []
                         for file in bundle:
                             data = torch.load(file)
-                            x.append(data["SIM"])
+                            x.append(data["SIM"].to_dense())
                             y.append(data["TRUTH"])
                             if not amp_phase:
                                 amp_phase = data["TYPE"]
 
+                        x = np.asarray(x)
+                        y = np.asarray(y)
+                        x = np.stack((x.real, x.imag), axis=1)
+                        y = np.stack((y.real, y.imag), axis=1)
+
                         writer.write(
-                            np.asarray(x),
-                            np.asarray(y),
-                            index=int(index),
-                            bundle_length=len(data["SIM"]),
+                            x, y, index=int(index), bundle_length=len(data["SIM"])
                         )
                         total_samples += len(x)
 

--- a/src/pyvisgen/io/datawriters.py
+++ b/src/pyvisgen/io/datawriters.py
@@ -681,8 +681,8 @@ class PTWriter(DataWriter):
 
     def write(
         self,
-        x: np.ndarray,
-        y: np.ndarray,
+        x: np.ndarray | torch.Tensor,
+        y: np.ndarray | torch.Tensor,
         *,
         index,
         bundle_length: int,
@@ -732,8 +732,10 @@ class PTWriter(DataWriter):
         if self.half_image:
             x, y = self.get_half_image(x, y, overlap=overlap)
 
-        x = torch.from_numpy(x)
-        y = torch.from_numpy(y)
+        if isinstance(x, np.ndarray):
+            x = torch.from_numpy(x)
+        if isinstance(y, np.ndarray):
+            y = torch.from_numpy(y)
 
         self.test_shapes(x, "X")
         self.test_shapes(y, "y")

--- a/src/pyvisgen/io/datawriters.py
+++ b/src/pyvisgen/io/datawriters.py
@@ -672,6 +672,7 @@ class PTWriter(DataWriter):
         """
         self.output_path = output_path
         self.dataset_type = dataset_type
+        self.half_image = half_image
 
         if amp_phase:
             self.data_type = "amp_phase"

--- a/src/pyvisgen/io/datawriters.py
+++ b/src/pyvisgen/io/datawriters.py
@@ -743,10 +743,10 @@ class PTWriter(DataWriter):
 
         for i in range(bundle_length):
             output_file = self.output_path / Path(
-                f"samp_{self.dataset_type}_{index + i}.pt"
+                f"samp_{self.dataset_type}_{index * bundle_length + i}.pt"
             )
 
             torch.save(
-                obj={"SIM": x.to_sparse(), "TRUTH": y, "TYPE": self.data_type},
+                obj={"SIM": x[i].to_sparse(), "TRUTH": y[i], "TYPE": self.data_type},
                 f=output_file,
             )

--- a/src/pyvisgen/io/datawriters.py
+++ b/src/pyvisgen/io/datawriters.py
@@ -119,7 +119,10 @@ class DataWriter(ABC):
         if array.shape[1] != 2:
             raise ValueError(
                 f"Expected array {name} axis 1 to be 2 but got "
-                f"{array.shape} with axis 1: {array.shape[1]}!"
+                f"{array.shape} with axis 1: {array.shape[1]}! "
+                "This usually indicates that the images do not have "
+                "separate channels for amplitude/phase or real/imaginary "
+                "data."
             )
 
         if array.ndim != 4:
@@ -647,7 +650,12 @@ class PTWriter(DataWriter):
     """
 
     def __init__(
-        self, output_path: Path, dataset_type: str, amp_phase: bool, **kwargs
+        self,
+        output_path: Path,
+        dataset_type: str,
+        amp_phase: bool,
+        half_image: bool = True,
+        **kwargs,
     ) -> None:
         """Initialize the PT writer.
 
@@ -711,7 +719,7 @@ class PTWriter(DataWriter):
         --------
         >>> rng = np.random.default_rng()
         >>>
-        >>> with H5Writer(
+        >>> with PTWriter(
         ...     output_path="./data", dataset_type="train", amp_phase=True
         ... ) as writer:
         ...     x_data = rng.uniform(size=(5, 10, 2, 256, 256))
@@ -720,7 +728,9 @@ class PTWriter(DataWriter):
         ...     for bundle_id, (x, y) in enumerate(zip(x_data, y_data)):
         ...         writer.write(x, y, index=bundle_id, bundle_length=len(x))
         """
-        x, y = self.get_half_image(x, y, overlap=overlap)
+        if self.half_image:
+            x, y = self.get_half_image(x, y, overlap=overlap)
+
         x = torch.from_numpy(x)
         y = torch.from_numpy(y)
 

--- a/src/pyvisgen/tools/cli.py
+++ b/src/pyvisgen/tools/cli.py
@@ -2,19 +2,15 @@ import rich_click as click
 
 from pyvisgen import __version__
 
+from .converter import main as converter
 from .create_dataset import main as create_dataset
 from .quickstart import main as quickstart
 
 click.rich_click.COMMAND_GROUPS = {
     "pyvisgen": [
-        {
-            "name": "Simulation",
-            "commands": ["simulate"],
-        },
-        {
-            "name": "Setup",
-            "commands": ["quickstart"],
-        },
+        {"name": "Simulation", "commands": ["simulate"]},
+        {"name": "Setup", "commands": ["quickstart"]},
+        {"name": "Data Format Conversion", "commands": ["convert"]},
     ]
 }
 
@@ -31,6 +27,7 @@ def main():
 
 main.add_command(quickstart, name="quickstart")
 main.add_command(create_dataset, name="simulate")
+main.add_command(converter, name="convert")
 
 if __name__ == "__main__":
     main()

--- a/src/pyvisgen/tools/converter.py
+++ b/src/pyvisgen/tools/converter.py
@@ -76,6 +76,16 @@ from pyvisgen.io import DataConverter
         Not applied for other data formats.
     """,
 )
+@click.option(
+    "--bundle-size",
+    type=int,
+    default=100,
+    help="""
+        Bundle size used when converting from [bold blue]PyTorch[/] pickle files.
+        Not applied when converting from different data formats.
+    """,
+    show_default=True,
+)
 def main(
     input_dir: str,
     output_dir: str | None,
@@ -85,6 +95,7 @@ def main(
     amp_phase: bool,
     shard_pattern: str,
     compress: bool,
+    bundle_size: int,
 ) -> None:
     """Data format conversion tool for pyvisgen."""
     input_format = input_format.lower()
@@ -107,6 +118,7 @@ def main(
         amp_phase=amp_phase,
         shard_pattern=shard_pattern,
         compress=compress,
+        bundle_size=bundle_size,
     )
 
 

--- a/src/pyvisgen/tools/converter.py
+++ b/src/pyvisgen/tools/converter.py
@@ -1,0 +1,99 @@
+import rich_click as click
+
+from pyvisgen.io import DataConverter
+
+
+@click.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_extra_args=True,
+    ),
+    epilog="""
+    See https://pyvisgen.readthedocs.io/en/latest/api/pyvisgen.io.dataconverter.DataConverter.html
+    for more information on extra arguments.
+    """,
+)
+@click.pass_context
+@click.argument(
+    "input_dir",
+    type=click.Path(exists=True, dir_okay=True),
+)
+@click.option(
+    "--output-dir",
+    "-o",
+    type=click.Path(dir_okay=True),
+    default=None,
+    help="Output directory. Defaults to input directory.",
+)
+@click.option(
+    "--input-format",
+    type=click.Choice(["h5", "wds"], case_sensitive=False),
+    default="h5",
+    help="Data format of the input dataset.",
+    show_default=True,
+)
+@click.option(
+    "--output-format",
+    type=click.Choice(["h5", "wds"], case_sensitive=False),
+    default="wds",
+    help="Data format of the output dataset.",
+    show_default=True,
+)
+@click.option(
+    "--dataset_type",
+    "-d",
+    type=click.Choice(
+        [
+            "all",
+            "train",
+            "valid",
+            "test",
+        ],
+        case_sensitive=False,
+    ),
+    default="all",
+    show_default=True,
+)
+def main(
+    ctx: click.Context,
+    input_dir: str,
+    output_dir: str | None,
+    input_format: str,
+    output_format: str,
+    dataset_type: str,
+):
+    """Data format conversion tool for pyvisgen."""
+    input_format = input_format.lower()
+    output_format = output_format.lower()
+    dataset_type = dataset_type.lower()
+
+    if input_format == output_format:
+        raise ValueError(
+            "Expected input and output format to be different but "
+            f"got '{input_format}', '{output_format}'."
+        )
+
+    output_dir = output_dir or input_dir  # If output_dir is None, use input_dir
+
+    kwargs = {}
+    args = ctx.args
+    if args:
+        if len(args) % 2 != 0:
+            raise click.UsageError(
+                "Extra arguments must be key-value pairs: --key value", ctx
+            )
+        # Remove (left) dashes from flags, and replace dashes in args
+        # with underscores so that, e.g. amp-phase will become amp_phase
+        # (just in case)
+        keys = [k.lstrip("-").replace("-", "_") for k in args[::2]]
+        kwargs = dict(zip(keys, args[1::2]))
+
+    # Get correct converter from DataConverter attribute
+    converter = getattr(DataConverter, f"from_{input_format}")
+    converter(input_dir, dataset_type=dataset_type).to(
+        output_dir, output_format=output_format, **kwargs
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyvisgen/tools/converter.py
+++ b/src/pyvisgen/tools/converter.py
@@ -63,7 +63,7 @@ from pyvisgen.io import DataConverter
     default="%06d.tar",
     help="""
         Shard pattern for [bold blue]WebDataset[/] files. Must be a C-style format
-        specifier with the '.tar' file suffix. Has no effect on other
+        specifier with the '.tar' file suffix. Not applied for other
         data formats.
     """,
     show_default=True,
@@ -72,8 +72,8 @@ from pyvisgen.io import DataConverter
     "--compress",
     is_flag=True,
     help="""
-        Whether to compress [bold blue]WebDataset[/] shards using gzip. Has no effect
-        other data formats.
+        Whether to compress [bold blue]WebDataset[/] shards using gzip.
+        Not applied for other data formats.
     """,
 )
 def main(

--- a/src/pyvisgen/tools/converter.py
+++ b/src/pyvisgen/tools/converter.py
@@ -89,7 +89,7 @@ def main(
         kwargs = dict(zip(keys, args[1::2]))
 
     # Get correct converter from DataConverter attribute
-    converter = getattr(DataConverter, f"from_{input_format}")
+    converter: DataConverter = getattr(DataConverter, f"from_{input_format}")
     converter(input_dir, dataset_type=dataset_type).to(
         output_dir, output_format=output_format, **kwargs
     )

--- a/src/pyvisgen/tools/converter.py
+++ b/src/pyvisgen/tools/converter.py
@@ -31,7 +31,7 @@ from pyvisgen.io import DataConverter
 )
 @click.option(
     "--dataset_type",
-    "-d",
+    "-t",
     type=click.Choice(
         [
             "all",
@@ -41,6 +41,7 @@ from pyvisgen.io import DataConverter
         ],
         case_sensitive=False,
     ),
+    multiple=True,
     default="all",
     help="""Choose between different splits of the datasets to convert.
         'all' converts 'train', 'valid', and 'test' splits in one go.
@@ -88,7 +89,7 @@ def main(
     """Data format conversion tool for pyvisgen."""
     input_format = input_format.lower()
     output_format = output_format.lower()
-    dataset_type = dataset_type.lower()
+    dataset_type = [t.lower() for t in dataset_type]
 
     if input_format == output_format:
         raise click.BadParameter(

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -1,0 +1,139 @@
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pyarrow as pa
+import pytest
+import torch
+import webdataset as wds
+
+
+@pytest.fixture
+def sample_data() -> tuple[np.ndarray, np.ndarray]:
+    rng = np.random.default_rng(42)
+
+    shape = (4, 2, 16, 32)
+    x = rng.random(shape, dtype=np.float32)
+    y = rng.random(shape, dtype=np.float32)
+
+    return x, y
+
+
+@pytest.fixture
+def h5_dataset(tmp_path: Path, sample_data: tuple[np.ndarray, np.ndarray]) -> Path:
+    x, y = sample_data
+
+    if not tmp_path.is_dir():
+        tmp_path.mkdir()
+
+    for split in ["train", "valid", "test"]:
+        file = tmp_path / f"samp_{split}_0.h5"
+
+        with h5py.File(file, "w") as f:
+            f.create_dataset("x", data=x)
+            f.create_dataset("y", data=y)
+
+    return tmp_path
+
+
+@pytest.fixture
+def wds_dataset(tmp_path: Path, sample_data: tuple[np.ndarray, np.ndarray]) -> Path:
+    x, y = sample_data
+
+    if not tmp_path.is_dir():
+        tmp_path.mkdir()
+
+    for split in ["train", "valid", "test"]:
+        shard_path = tmp_path / f"{split}-000000.tar.gz"
+
+        with wds.TarWriter(str(shard_path), compress=True) as tarwriter:
+            for i in range(len(x)):
+                tarwriter.write({
+                    "__key__": f"{split}_{i:08d}",
+                    "input.npy": x[i],
+                    "target.npy": y[i],
+                })
+
+        metadict = {
+            "total_samples_in_dataset": [len(x)],
+            "samples_in_shard": [len(x)],
+            "shard_idx": [0],
+            "bundle_id": [0],
+            "data_type": ["amp_phase"],
+        }
+        metadata = pa.Table.from_pydict(metadict)
+        metadata_path = (
+            str(shard_path).replace(".tar.gz", ".parquet")
+        )
+        pa.parquet.write_table(metadata, metadata_path)
+
+        return tmp_path
+
+
+@pytest.fixture
+def pt_dataset(tmp_path: Path, sample_data: tuple[np.ndarray, np.ndarray]) -> Path:
+    x, y = sample_data
+
+    x = torch.from_numpy(x)
+    y = torch.from_numpy(y)
+
+    x = x[:, 0] + 1j * x[:, 1]
+    y = y[:, 0] + 1j * y[:, 1]
+
+    for split in ["train", "valid", "test"]:
+        for i in range(len(x)):
+            file_path = tmp_path / f"samp_{split}_{i + 1}.pt"
+
+            torch.save(
+                obj={"SIM": x[i].to_sparse(), "TRUTH": y[i], "TYPE": "amp_phase"},
+                f=file_path,
+            )
+
+    return tmp_path
+
+
+class TestImage:
+
+    @staticmethod
+    def get_h5(file: Path) -> tuple[np.ndarray, np.ndarray]:
+        with h5py.File(file) as f:
+            x = np.asarray(f["x"], dtype=np.float32)[0]
+            y = np.asarray(f["y"], dtype=np.float32)[0]
+
+        return x, y
+
+    @staticmethod
+    def get_wds(file: Path) -> tuple[np.ndarray, np.ndarray]:
+        webdataset = (
+            wds.WebDataset(str(file), shardshuffle=False)
+            .decode()
+            .to_tuple("input.npy", "target.npy")
+        )
+
+        x, y = next(iter(webdataset))
+
+        meta_file = (
+            str(file).replace(".tar.gz", ".parquet")
+            if str(file).endswith(".tar.gz")
+            else str(file).replace(".tar", ".parquet")
+        )
+        metadata = pa.parquet.read_table(meta_file).to_pandas()
+        data_type = metadata["data_type"][0]
+
+        return x, y, data_type
+
+    @staticmethod
+    def get_pt(file: Path) -> tuple[np.ndarray, np.ndarray]:
+        data = torch.load(file)
+        x = data["SIM"].to_dense()
+        y = data["TRUTH"]
+        data_type = data["TYPE"]
+
+        x = np.stack((x.real, x.imag), axis=0)
+        y = np.stack((y.real, y.imag), axis=0)
+
+        return x, y, data_type
+
+@pytest.fixture
+def test_image():
+    return TestImage

--- a/tests/io/test_dataconverter.py
+++ b/tests/io/test_dataconverter.py
@@ -1,0 +1,234 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+import webdataset as wds
+
+from pyvisgen.io.dataconverter import DataConverter, _batch_array
+
+
+class TestBatchArray:
+
+    def test_split_even(self) -> None:
+        arr = np.arange(20)
+        batches = _batch_array(arr, batch_size=10)
+
+        assert len(batches) == 2
+        np.testing.assert_array_equal(batches[0], np.arange(10))
+        np.testing.assert_array_equal(batches[1], np.arange(10, 20))
+
+    def test_split_uneven(self) -> None:
+        arr = np.arange(21)
+        batches = _batch_array(arr, batch_size=10)
+
+        assert len(batches) == 3
+        assert len(batches[-1]) == 1
+        np.testing.assert_array_equal(batches[2], np.arange(20, 21))
+
+    def test_return_indices(self) -> None:
+        arr = np.arange(20)
+        batches, indices = _batch_array(arr, batch_size=5, return_indices=True)
+
+        assert len(batches) == 4
+        np.testing.assert_array_equal(indices, [0, 5, 10, 15])
+
+    def test_batch_larger_than_array(self) -> None:
+        arr = np.arange(20)
+        batches = _batch_array(arr, batch_size=40)
+
+        assert len(batches) == 1
+        np.testing.assert_array_equal(batches[0], arr)
+
+
+class TestDataConverterFromDataset:
+
+    def test_from_h5(self, h5_dataset: Path) -> None:
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
+
+        assert converter._FMT == "h5"
+        assert set(converter.datasets) == {"train"}
+        assert len(list(converter.datasets["train"])) == 1  # expect 1 file
+
+    def test_from_wds(self, wds_dataset: Path) -> None:
+        converter = DataConverter.from_wds(wds_dataset, dataset_split="train")
+
+        assert converter._FMT == "wds"
+        assert set(converter.datasets) == {"train"}
+        assert len(list(converter.datasets["train"])) == 1  # expect 1 file
+
+    def test_from_pt(self, pt_dataset: Path) -> None:
+        converter = DataConverter.from_pt(pt_dataset, dataset_split="train")
+
+        assert converter._FMT == "pt"
+        assert set(converter.datasets) == {"train"}
+
+        # expect 4 files since sample_data.shape[0] == 4
+        # (each image is saved to an individual file)
+        assert len(list(converter.datasets["train"])) == 4
+
+    def test_dataset_split_all(self, h5_dataset: Path) -> None:
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="all")
+
+        assert set(converter.datasets) == {"train", "valid", "test"}
+        assert len(list(converter.datasets["train"])) == 1
+        assert len(list(converter.datasets["valid"])) == 1
+        assert len(list(converter.datasets["test"])) == 1
+
+    def test_dataset_split_list(self, h5_dataset: Path) -> None:
+        converter = DataConverter.from_h5(h5_dataset, dataset_split=["train", "valid"])
+
+        assert set(converter.datasets) == {"train", "valid"}
+
+
+class TestDataConverterToDataset:
+
+    def test_same_format_raises(self, tmp_path: Path, h5_dataset: Path) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
+
+        with pytest.raises(RuntimeError) as excinfo:
+            converter.to(output_dir, output_format="h5")
+
+        assert "Forbidden: Cannot convert h5 to h5" in str(excinfo.value)
+
+    def test_create_output_dir(self, tmp_path: Path, h5_dataset: Path) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="pt")
+
+        assert output_dir.is_dir()
+
+    def test_h5_to_wds(
+        self,
+        tmp_path: Path,
+        h5_dataset: Path,
+        test_image: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="wds")
+
+        wds_shards = list(output_dir.glob("*.tar.gz"))
+        parquet_files = list(output_dir.glob("*.parquet"))
+        assert len(wds_shards) == 1
+        assert len(parquet_files) == 1
+
+        x, y = test_image.get_h5(tmp_path / "samp_train_0.h5")
+        x_wds, y_wds, data_type = test_image.get_wds(file=wds_shards[0])
+
+        np.testing.assert_array_equal(x, x_wds)
+        np.testing.assert_array_equal(y, y_wds)
+
+        assert data_type == "amp_phase"
+
+    def test_h5_to_pt(
+        self,
+        tmp_path: Path,
+        h5_dataset: Path,
+        test_image: tuple[np.ndarray, np.ndarray],
+    ) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="pt")
+
+        pt_files = sorted(output_dir.glob("*.pt"))
+        assert len(pt_files) == 4
+
+        x, y = test_image.get_h5(tmp_path / "samp_train_0.h5")
+        x_pt, y_pt, data_type = test_image.get_pt(file=pt_files[0])
+
+        np.testing.assert_array_equal(x, x_pt)
+        np.testing.assert_array_equal(y, y_pt)
+
+        assert data_type == "amp_phase"
+
+    def test_wds_to_h5(
+        self,
+        tmp_path: Path,
+        wds_dataset: Path,
+        test_image: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_wds(wds_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="h5")
+
+        h5_files = list(output_dir.glob("*.h5"))
+        assert len(h5_files) == 1
+
+        x, y, _ = test_image.get_wds(tmp_path / "train-000000.tar.gz")
+        x_h5, y_h5 = test_image.get_h5(h5_files[0])
+
+        np.testing.assert_array_equal(x, x_h5)
+        np.testing.assert_array_equal(y, y_h5)
+
+    def test_wds_to_pt(
+        self,
+        tmp_path: Path,
+        wds_dataset: Path,
+        test_image: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_wds(wds_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="pt")
+
+        pt_files = sorted(output_dir.glob("*.pt"))
+        assert len(pt_files) == 4
+
+        x, y, data_type = test_image.get_wds(tmp_path / "train-000000.tar.gz")
+        x_pt, y_pt, data_type_pt = test_image.get_pt(file=pt_files[0])
+
+        np.testing.assert_array_equal(x, x_pt)
+        np.testing.assert_array_equal(y, y_pt)
+
+        assert data_type_pt == data_type  # "amp_phase"
+
+    def test_pt_to_h5(
+        self,
+        tmp_path: Path,
+        pt_dataset: Path,
+        test_image: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_pt(pt_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="h5")
+
+        h5_files = list(output_dir.glob("*.h5"))
+        assert len(h5_files) == 1
+
+        x, y, _ = test_image.get_pt(tmp_path / "samp_train_1.pt")
+        x_h5, y_h5 = test_image.get_h5(h5_files[0])
+
+        np.testing.assert_array_equal(x, x_h5)
+        np.testing.assert_array_equal(y, y_h5)
+
+    def test_pt_to_wds(
+        self,
+        tmp_path: Path,
+        pt_dataset: Path,
+        test_image: tuple[np.ndarray, np.ndarray]
+    ) -> None:
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_pt(pt_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="wds")
+
+        wds_shards = list(output_dir.glob("*.tar.gz"))
+        parquet_files = list(output_dir.glob("*.parquet"))
+        assert len(wds_shards) == 1
+        assert len(parquet_files) == 1
+
+        x, y, data_type = test_image.get_pt(tmp_path / "samp_train_1.pt")
+        x_wds, y_wds, data_type_wds = test_image.get_wds(file=wds_shards[0])
+
+        np.testing.assert_array_equal(x, x_wds)
+        np.testing.assert_array_equal(y, y_wds)
+
+        assert data_type_wds == data_type  # "amp_phase"

--- a/tests/io/test_dataconverter.py
+++ b/tests/io/test_dataconverter.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from pathlib import Path
 
 import numpy as np
@@ -5,11 +6,10 @@ import pytest
 import torch
 import webdataset as wds
 
-from pyvisgen.io.dataconverter import DataConverter, _batch_array
+from pyvisgen.io.dataconverter import DataConverter, _batch_array, DataTypeConverter
 
 
 class TestBatchArray:
-
     def test_split_even(self) -> None:
         arr = np.arange(20)
         batches = _batch_array(arr, batch_size=10)
@@ -42,7 +42,6 @@ class TestBatchArray:
 
 
 class TestDataConverterFromDataset:
-
     def test_from_h5(self, h5_dataset: Path) -> None:
         converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
 
@@ -82,7 +81,6 @@ class TestDataConverterFromDataset:
 
 
 class TestDataConverterToDataset:
-
     def test_same_format_raises(self, tmp_path: Path, h5_dataset: Path) -> None:
         output_dir = tmp_path / "output/"
 
@@ -93,6 +91,21 @@ class TestDataConverterToDataset:
 
         assert "Forbidden: Cannot convert h5 to h5" in str(excinfo.value)
 
+    def test_convert_without_amp_phase(self, tmp_path: Path, h5_dataset: Path):
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
+
+        with pytest.raises(ValueError) as excinfo:
+            converter.to(
+                output_dir,
+                output_format="h5",
+                amp_phase=None,
+                convert_representation=True,
+            )
+
+        assert "Cannot convert data representation" in str(excinfo.value)
+
     def test_create_output_dir(self, tmp_path: Path, h5_dataset: Path) -> None:
         output_dir = tmp_path / "output/"
 
@@ -101,8 +114,10 @@ class TestDataConverterToDataset:
 
         assert output_dir.is_dir()
 
+    @pytest.mark.parametrize("convert", [True, False])
     def test_h5_to_wds(
         self,
+        convert: bool,
         tmp_path: Path,
         h5_dataset: Path,
         test_image: tuple[np.ndarray, np.ndarray],
@@ -110,23 +125,26 @@ class TestDataConverterToDataset:
         output_dir = tmp_path / "output/"
 
         converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
-        converter.to(output_dir, output_format="wds")
+        converter.to(output_dir, output_format="wds", convert_representation=convert)
 
         wds_shards = list(output_dir.glob("*.tar.gz"))
         parquet_files = list(output_dir.glob("*.parquet"))
         assert len(wds_shards) == 1
         assert len(parquet_files) == 1
 
-        x, y = test_image.get_h5(tmp_path / "samp_train_0.h5")
-        x_wds, y_wds, data_type = test_image.get_wds(file=wds_shards[0])
+        if not convert:
+            x, y = test_image.get_h5(tmp_path / "samp_train_0.h5")
+            x_wds, y_wds, data_type = test_image.get_wds(file=wds_shards[0])
 
-        np.testing.assert_array_equal(x, x_wds)
-        np.testing.assert_array_equal(y, y_wds)
+            np.testing.assert_array_equal(x, x_wds)
+            np.testing.assert_array_equal(y, y_wds)
 
-        assert data_type == "amp_phase"
+            assert data_type == "amp_phase"
 
+    @pytest.mark.parametrize("convert", [True, False])
     def test_h5_to_pt(
         self,
+        convert: bool,
         tmp_path: Path,
         h5_dataset: Path,
         test_image: tuple[np.ndarray, np.ndarray],
@@ -134,101 +152,181 @@ class TestDataConverterToDataset:
         output_dir = tmp_path / "output/"
 
         converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
-        converter.to(output_dir, output_format="pt")
+        converter.to(output_dir, output_format="pt", convert_representation=convert)
 
         pt_files = sorted(output_dir.glob("*.pt"))
         assert len(pt_files) == 4
 
-        x, y = test_image.get_h5(tmp_path / "samp_train_0.h5")
-        x_pt, y_pt, data_type = test_image.get_pt(file=pt_files[0])
+        if not convert:
+            x, y = test_image.get_h5(tmp_path / "samp_train_0.h5")
+            x_pt, y_pt, data_type = test_image.get_pt(file=pt_files[0])
 
-        np.testing.assert_array_equal(x, x_pt)
-        np.testing.assert_array_equal(y, y_pt)
+            np.testing.assert_array_equal(x, x_pt)
+            np.testing.assert_array_equal(y, y_pt)
 
-        assert data_type == "amp_phase"
+            assert data_type == "amp_phase"
 
+    @pytest.mark.parametrize("convert", [True, False])
     def test_wds_to_h5(
         self,
+        convert: bool,
         tmp_path: Path,
         wds_dataset: Path,
-        test_image: tuple[np.ndarray, np.ndarray]
+        test_image: tuple[np.ndarray, np.ndarray],
     ) -> None:
         output_dir = tmp_path / "output/"
 
         converter = DataConverter.from_wds(wds_dataset, dataset_split="train")
-        converter.to(output_dir, output_format="h5")
+        converter.to(output_dir, output_format="h5", convert_representation=convert)
 
         h5_files = list(output_dir.glob("*.h5"))
         assert len(h5_files) == 1
 
-        x, y, _ = test_image.get_wds(tmp_path / "train-000000.tar.gz")
-        x_h5, y_h5 = test_image.get_h5(h5_files[0])
+        if not convert:
+            x, y, _ = test_image.get_wds(tmp_path / "train-000000.tar.gz")
+            x_h5, y_h5 = test_image.get_h5(h5_files[0])
 
-        np.testing.assert_array_equal(x, x_h5)
-        np.testing.assert_array_equal(y, y_h5)
+            np.testing.assert_array_equal(x, x_h5)
+            np.testing.assert_array_equal(y, y_h5)
 
+    @pytest.mark.parametrize("convert", [True, False])
     def test_wds_to_pt(
         self,
+        convert: bool,
         tmp_path: Path,
         wds_dataset: Path,
-        test_image: tuple[np.ndarray, np.ndarray]
+        test_image: tuple[np.ndarray, np.ndarray],
     ) -> None:
         output_dir = tmp_path / "output/"
 
         converter = DataConverter.from_wds(wds_dataset, dataset_split="train")
-        converter.to(output_dir, output_format="pt")
+        converter.to(output_dir, output_format="pt", convert_representation=convert)
 
         pt_files = sorted(output_dir.glob("*.pt"))
         assert len(pt_files) == 4
 
-        x, y, data_type = test_image.get_wds(tmp_path / "train-000000.tar.gz")
-        x_pt, y_pt, data_type_pt = test_image.get_pt(file=pt_files[0])
+        if not convert:
+            x, y, data_type = test_image.get_wds(tmp_path / "train-000000.tar.gz")
+            x_pt, y_pt, data_type_pt = test_image.get_pt(file=pt_files[0])
 
-        np.testing.assert_array_equal(x, x_pt)
-        np.testing.assert_array_equal(y, y_pt)
+            np.testing.assert_array_equal(x, x_pt)
+            np.testing.assert_array_equal(y, y_pt)
 
-        assert data_type_pt == data_type  # "amp_phase"
+            assert data_type_pt == data_type  # "amp_phase"
 
+    @pytest.mark.parametrize("convert", [True, False])
     def test_pt_to_h5(
         self,
+        convert: bool,
         tmp_path: Path,
         pt_dataset: Path,
-        test_image: tuple[np.ndarray, np.ndarray]
+        test_image: tuple[np.ndarray, np.ndarray],
     ) -> None:
         output_dir = tmp_path / "output/"
 
         converter = DataConverter.from_pt(pt_dataset, dataset_split="train")
-        converter.to(output_dir, output_format="h5")
+        converter.to(output_dir, output_format="h5", convert_representation=convert)
 
         h5_files = list(output_dir.glob("*.h5"))
         assert len(h5_files) == 1
 
-        x, y, _ = test_image.get_pt(tmp_path / "samp_train_1.pt")
-        x_h5, y_h5 = test_image.get_h5(h5_files[0])
+        if not convert:
+            x, y, _ = test_image.get_pt(tmp_path / "samp_train_1.pt")
+            x_h5, y_h5 = test_image.get_h5(h5_files[0])
 
-        np.testing.assert_array_equal(x, x_h5)
-        np.testing.assert_array_equal(y, y_h5)
+            np.testing.assert_array_equal(x, x_h5)
+            np.testing.assert_array_equal(y, y_h5)
 
+    @pytest.mark.parametrize("convert", [True, False])
     def test_pt_to_wds(
         self,
+        convert: bool,
         tmp_path: Path,
         pt_dataset: Path,
-        test_image: tuple[np.ndarray, np.ndarray]
+        test_image: tuple[np.ndarray, np.ndarray],
     ) -> None:
         output_dir = tmp_path / "output/"
 
         converter = DataConverter.from_pt(pt_dataset, dataset_split="train")
-        converter.to(output_dir, output_format="wds")
+        converter.to(output_dir, output_format="wds", convert_representation=convert)
 
         wds_shards = list(output_dir.glob("*.tar.gz"))
         parquet_files = list(output_dir.glob("*.parquet"))
         assert len(wds_shards) == 1
         assert len(parquet_files) == 1
 
-        x, y, data_type = test_image.get_pt(tmp_path / "samp_train_1.pt")
-        x_wds, y_wds, data_type_wds = test_image.get_wds(file=wds_shards[0])
+        if not convert:
+            x, y, data_type = test_image.get_pt(tmp_path / "samp_train_1.pt")
+            x_wds, y_wds, data_type_wds = test_image.get_wds(file=wds_shards[0])
 
-        np.testing.assert_array_equal(x, x_wds)
-        np.testing.assert_array_equal(y, y_wds)
+            np.testing.assert_array_equal(x, x_wds)
+            np.testing.assert_array_equal(y, y_wds)
 
-        assert data_type_wds == data_type  # "amp_phase"
+            assert data_type_wds == data_type  # "amp_phase"
+
+    def test_repr_self_convert_h5(self, tmp_path: Path, h5_dataset: Path):
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_h5(h5_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="h5", convert_representation=True)
+
+        h5_files = list(output_dir.glob("*.h5"))
+        assert len(h5_files) == 1
+
+    def test_repr_self_convert_wds(self, tmp_path: Path, wds_dataset: Path):
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_wds(wds_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="wds", convert_representation=True)
+
+        wds_shards = list(output_dir.glob("*.tar.gz"))
+        parquet_files = list(output_dir.glob("*.parquet"))
+        assert len(wds_shards) == 1
+        assert len(parquet_files) == 1
+
+    def test_repr_self_convert_pt(self, tmp_path: Path, pt_dataset: Path):
+        output_dir = tmp_path / "output/"
+
+        converter = DataConverter.from_pt(pt_dataset, dataset_split="train")
+        converter.to(output_dir, output_format="pt", convert_representation=True)
+
+        pt_files = sorted(output_dir.glob("*.pt"))
+        assert len(pt_files) == 4
+
+
+class TestDataTypeConverter:
+    @pytest.fixture
+    def data(self):
+        x = torch.ones((10, 32, 32))
+        y = torch.zeros((10, 32, 32))
+
+        data = torch.stack((x, y), dim=1)
+
+        return data
+
+    def test_to_amp_phase(self, data):
+        dtype_conv = DataTypeConverter()
+
+        conv = dtype_conv.to_amp_phase(data)
+
+        assert conv.shape == data.shape
+        np.testing.assert_array_equal(conv[:, 0], torch.ones((10, 32, 32)))
+        np.testing.assert_array_equal(conv[:, 1], torch.zeros((10, 32, 32)))
+
+    def test_to_real_imag(self, data):
+        dtype_conv = DataTypeConverter()
+
+        conv = dtype_conv.to_real_imag(data)
+
+        assert conv.shape == data.shape
+        np.testing.assert_array_equal(conv[:, 0], torch.ones((10, 32, 32)))
+        np.testing.assert_array_equal(conv[:, 1], torch.zeros((10, 32, 32)))
+
+    @patch.object(DataTypeConverter, "to_amp_phase")
+    @patch.object(DataTypeConverter, "to_real_imag")
+    def test_convert(self, mock_to_real_imag, mock_to_amp_phase, data):
+        DataTypeConverter(input_amp_phase=True).convert(data)
+        mock_to_real_imag.assert_called_once_with(data)
+
+        DataTypeConverter(input_amp_phase=False).convert(data)
+        mock_to_amp_phase.assert_called_once_with(data)


### PR DESCRIPTION
Adds a data converter class that allows conversion between data formats for `pyvisgen`.

With this we can skip doing simulations over and over to get the same data in different formats, thus saving us many hours (e.g. ~20 min of conversion vs ~25h of new simulations).

## To-Do
- [x] PT support
- [x] Docstrings & type hints
- [x] Docs pages
- [x] CLI tool
- [x] Tests
- [x] Changelog

*Note*: I don't plan to include FITS for now, until we have fixed our FITS writer. Once that is taken care of, we can add FITS conversion, too.

~*Note 2*: Draft for now until I have added the items from the To-Do list.~

~Merge after #134~