### PR TITLE
Refactor RIME

### DIFF
--- a/docs/changes/145.feature.rst
+++ b/docs/changes/145.feature.rst
@@ -1,0 +1,2 @@
+Breaking Change: Refactored now removed :func:`pyvisgen.simulation.scan.rime` function as a new class-based API :class:`~pyvisgen.simulation.scan.RIMEScan`
+With this structure, the `CupyFinufft` wrapper can now be initialized correctly with the actual observation parameters instead of hard coded parameters.

--- a/src/pyvisgen/simulation/__init__.py
+++ b/src/pyvisgen/simulation/__init__.py
@@ -1,6 +1,6 @@
 from .array import Array
 from .observation import Baselines, Observation, ValidBaselineSubset
-from .scan import angular_distance, calc_beam, calc_fourier, integrate, jinc, rime
+from .scan import RIMEScan, angular_distance, calc_beam, calc_fourier, integrate, jinc
 from .visibility import Polarization, Visibilities, generate_noise, vis_loop
 
 __all__ = [
@@ -16,6 +16,6 @@ __all__ = [
     "generate_noise",
     "integrate",
     "jinc",
-    "rime",
+    "RIMEScan",
     "vis_loop",
 ]

--- a/src/pyvisgen/simulation/scan.py
+++ b/src/pyvisgen/simulation/scan.py
@@ -183,52 +183,41 @@ def apply_finufft(
     v_coords_high = bas.v_valid / c * spw_high
     w_coords_high = bas.w_valid / c * spw_high
 
-    n_baselines = len(bas.u_valid)
-
-    # Pre-allocate output
-    vis = torch.empty([n_baselines, 2, 2], dtype=torch.complex128, device=X1.device)
-
     # Reshape input
-    X1_flat = X1.reshape(4, -1)
-    X2_flat = X2.reshape(4, -1)
-
-    # Create CUDA streams for parallel execution of the 4 Stokes params
-    streams = [torch.cuda.Stream() for _ in range(4)]
+    X1_flat = X1.permute(1, 2, 0).reshape(4, -1)
+    X2_flat = X2.permute(1, 2, 0).reshape(4, -1)
 
     results_low = []
     results_high = []
 
     for i in range(4):
-        with torch.cuda.stream(streams[i]):
-            vis_low = finufft.nufft(
-                X1_flat[i],
-                l_coords,
-                m_coords,
-                n_coords,
-                u_coords_low,
-                v_coords_low,
-                w_coords_low,
-            )
-            vis_high = finufft.nufft(
-                X2_flat[i],
-                l_coords,
-                m_coords,
-                n_coords,
-                u_coords_high,
-                v_coords_high,
-                w_coords_high,
-            )
-            results_low.append(vis_low)
-            results_high.append(vis_high)
-
-    # Synchronize all streams
-    torch.cuda.synchronize()
+        vis_low = finufft.nufft(
+            X1_flat[i],
+            l_coords,
+            m_coords,
+            n_coords,
+            u_coords_low,
+            v_coords_low,
+            w_coords_low,
+        )
+        vis_high = finufft.nufft(
+            X2_flat[i],
+            l_coords,
+            m_coords,
+            n_coords,
+            u_coords_high,
+            v_coords_high,
+            w_coords_high,
+        )
+        results_low.append(vis_low)
+        results_high.append(vis_high)
 
     # Stack and reshape
     vis_low_all = torch.stack(results_low)
     vis_high_all = torch.stack(results_high)
+
     vis_avg = (vis_low_all + vis_high_all) / 2
-    vis = vis_avg.T.reshape(n_baselines, 2, 2)
+    vis = vis_avg.mT.reshape(-1, 2, 2)
 
     return vis
 

--- a/src/pyvisgen/simulation/scan.py
+++ b/src/pyvisgen/simulation/scan.py
@@ -28,18 +28,6 @@ __all__ = [
 ]
 
 
-# class JonesMatrix(ABC):
-#     @abstractmethod
-#     def __call__(
-#         self, X1: torch.Tensor, X2, torch: torch.Tensor, **ctx
-#     ) -> tuple[torch.Tensor, torch.Tensor]:
-#         """Apply the effect."""
-#
-#
-# class FTKernel(JonesMatrix):
-#     def __call__(self, X1, X2, bas=None, lm)
-
-
 class RIMEScan:
     def __init__(self, ft, mode, obs, lm, rd, eps=1e-8):
         if _FINUFFT_AVAIL:

--- a/src/pyvisgen/simulation/scan.py
+++ b/src/pyvisgen/simulation/scan.py
@@ -1,37 +1,23 @@
-from __future__ import annotations
-
 from math import pi
-from typing import TYPE_CHECKING
 
 import torch
 from scipy.constants import c
 from torch.special import bessel_j1
-
-if TYPE_CHECKING:
-    from typing import Literal
-
-    from numpy.typing import ArrayLike
 
 torch.set_default_dtype(torch.float64)
 
 try:
     from radioft.finufft import CupyFinufft
 
-    finufft = CupyFinufft(image_size=512, fov_arcsec=1024, eps=1e-8)
     _FINUFFT_AVAIL = True
 
 except ImportError as e:
-    from pyvisgen.utils import setup_logger
-
-    logger = setup_logger(__name__)
-    logger.warning(e)
-
     _FINUFFT_AVAIL = False
     _FINUFFT_ERROR = str(e)
 
 
 __all__ = [
-    "rime",
+    "RIMEScan",
     "apply_finufft",
     "calc_fourier",
     "calc_feed_rotation",
@@ -42,94 +28,145 @@ __all__ = [
 ]
 
 
-def rime(
-    img: ArrayLike,
-    bas: ArrayLike,
-    lm: ArrayLike,
-    rd: ArrayLike,
-    ra: ArrayLike,
-    dec: ArrayLike,
-    ant_diam: ArrayLike,
-    spw_low: ArrayLike,
-    spw_high: ArrayLike,
-    polarization: str | None,
-    mode: str,
-    corrupted: bool = False,
-    ft: Literal["default", "finufft", "reversed"] = "default",
-):
-    """Calculates visibilities using RIME
+# class JonesMatrix(ABC):
+#     @abstractmethod
+#     def __call__(
+#         self, X1: torch.Tensor, X2, torch: torch.Tensor, **ctx
+#     ) -> tuple[torch.Tensor, torch.Tensor]:
+#         """Apply the effect."""
+#
+#
+# class FTKernel(JonesMatrix):
+#     def __call__(self, X1, X2, bas=None, lm)
 
-    Parameters
-    ----------
-    img: torch.tensor
-        sky distribution
-    bas : dataclass object
-        baselines dataclass
-    lm : 2d array
-        lm grid for FOV
-    spw_low : float
-        lower wavelength
-    spw_high : float
-        higher wavelength
-    polarization : str
-        Type of polarization.
-    mode : str
-        Select one of `'full'`, `'grid'`, or `'dense'` to get
-        all valid baselines, a grid of unique baselines, or
-        dense baselines.
-    corrupted : bool, optional
-        If ``True``, apply beam smearing to the simulated data.
-        Default: ``False``
-    ft : str, optional
-        Sets the type of fourier transform used in the RIME.
-        Choose one of ``'default'``, ``'finufft'`` (Flatiron Institute
-        Nonuniform Fast Fourier Transform) or `'reversed'`.
-        Default: ``'default'``
 
-    Returns
-    -------
-    2d tensor
-        Returns visibility for every baseline
-    """
-    if ft == "default":
+class RIMEScan:
+    def __init__(self, ft, mode, obs, lm, rd, eps=1e-8):
+        if _FINUFFT_AVAIL:
+            self.cupy_finufft = CupyFinufft(
+                image_size=obs.img_size, fov_arcsec=obs.fov, eps=eps
+            )
+
+        self.mode = mode
+        self.ft = ft
+        self.ft_func = getattr(self, ft)
+        self.polarization = obs.polarization
+        self.corrupted = obs.corrupted
+        self.ra = obs.ra
+        self.dec = obs.dec
+        self.ant_diam = torch.unique(obs.array.diam)
+        self.lm = lm
+        self.rd = rd
+
+    def __call__(
+        self,
+        img: torch.Tensor,
+        bas,
+        spw_low: torch.Tensor,
+        spw_high: torch.Tensor,
+    ) -> torch.Tensor:
         with torch.no_grad():
+            if self.ft == "reversed":
+                img = torch.repeat_interleave(
+                    img.clone()[None], len(bas.u_valid), dim=0
+                )
+
             X1 = img.clone()
             X2 = img.clone()
-            X1, X2 = calc_fourier(X1, X2, bas, lm, spw_low, spw_high)
 
-            if polarization and mode != "dense":
-                X1, X2 = calc_feed_rotation(X1, X2, bas, polarization)
+            return self.ft_func(
+                X1,
+                X2,
+                bas,
+                spw_low,
+                spw_high,
+            )
 
-            if corrupted:
-                X1, X2 = calc_beam(X1, X2, rd, ra, dec, ant_diam, spw_low, spw_high)
+    def default(
+        self,
+        X1: torch.Tensor,
+        X2: torch.Tensor,
+        bas: torch.Tensor,
+        spw_low: torch.Tensor,
+        spw_high: torch.Tensor,
+    ) -> torch.Tensor:
+        X1, X2 = calc_fourier(X1, X2, bas, self.lm, spw_low, spw_high)
 
-            vis = integrate(X1, X2)
-    if ft == "reversed":
-        with torch.no_grad():
-            img = torch.repeat_interleave(img.clone()[None], len(bas.u_valid), dim=0)
-            X1 = img.clone()
-            X2 = img.clone()
-            if polarization and mode != "dense":
-                X1, X2 = calc_feed_rotation(X1, X2, bas, polarization)
+        if self.polarization and self.mode != "dense":
+            X1, X2 = calc_feed_rotation(X1, X2, bas, self.polarization)
 
-            if corrupted:
-                X1, X2 = calc_beam(X1, X2, rd, ra, dec, ant_diam, spw_low, spw_high)
+        if self.corrupted:
+            X1, X2 = calc_beam(
+                X1,
+                X2,
+                self.rd,
+                self.ra,
+                self.dec,
+                self.ant_diam,
+                spw_low,
+                spw_high,
+            )
 
-            X1, X2 = calc_fourier(X1, X2, bas, lm, spw_low, spw_high)
-            vis = integrate(X1, X2)
-    if ft == "finufft":
+        vis = integrate(X1, X2)
+
+        return vis
+
+    def reversed(
+        self,
+        X1: torch.Tensor,
+        X2: torch.Tensor,
+        bas: torch.Tensor,
+        spw_low: torch.Tensor,
+        spw_high: torch.Tensor,
+    ) -> torch.Tensor:
+        if self.polarization and self.mode != "dense":
+            X1, X2 = calc_feed_rotation(X1, X2, bas, self.polarization)
+
+        if self.corrupted:
+            X1, X2 = calc_beam(
+                X1,
+                X2,
+                self.rd,
+                self.ra,
+                self.dec,
+                self.ant_diam,
+                spw_low,
+                spw_high,
+            )
+
+        X1, X2 = calc_fourier(X1, X2, bas, self.lm, spw_low, spw_high)
+        vis = integrate(X1, X2)
+
+        return vis
+
+    def finufft(
+        self,
+        X1: torch.Tensor,
+        X2: torch.Tensor,
+        bas: torch.Tensor,
+        spw_low: torch.Tensor,
+        spw_high: torch.Tensor,
+    ) -> torch.Tensor:
         if not _FINUFFT_AVAIL:
             raise RuntimeError(_FINUFFT_ERROR)
 
-        with torch.no_grad():
-            X1 = img.clone()
-            X2 = img.clone()
+        if self.corrupted:
+            X1, X2 = calc_beam(
+                X1,
+                X2,
+                self.rd,
+                self.ra,
+                self.dec,
+                self.ant_diam,
+                spw_low,
+                spw_high,
+            )
 
-            if corrupted:
-                X1, X2 = calc_beam(X1, X2, rd, ra, dec, ant_diam, spw_low, spw_high)
+        vis = apply_finufft(
+            X1, X2, bas, self.lm, spw_low, spw_high, finufft=self.cupy_finufft
+        )
 
-            vis = apply_finufft(X1, X2, bas, lm, spw_low, spw_high)
-    return vis
+        return vis
 
 
 def apply_finufft(
@@ -137,9 +174,10 @@ def apply_finufft(
     X2: torch.Tensor,
     bas,
     lm: torch.Tensor,
-    spw_low: float,
-    spw_high: float,
-) -> tuple[torch.Tensor, torch.Tensor]:  # pragma: no cover
+    spw_low: float | torch.Tensor,
+    spw_high: float | torch.Tensor,
+    finufft: CupyFinufft,
+) -> torch.Tensor:  # pragma: no cover
     if not torch.cuda.is_available():
         raise RuntimeError(
             "CUDA is not available. Finufft backend requires a CUDA-enabled GPU to run."
@@ -212,8 +250,8 @@ def calc_fourier(
     X2: torch.Tensor,
     bas,
     lm: torch.Tensor,
-    spw_low: float,
-    spw_high: float,
+    spw_low: float | torch.Tensor,
+    spw_high: float | torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Calculates Fourier transformation kernel for
     every baseline and pixel in the lm grid.
@@ -263,11 +301,11 @@ def calc_fourier(
 
 
 def calc_feed_rotation(
-    X1: torch.tensor,
-    X2: torch.tensor,
+    X1: torch.Tensor,
+    X2: torch.Tensor,
     bas,
     polarization: str,
-) -> tuple[torch.tensor, torch.tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Calculates the feed rotation due to the parallactic
     angle rotation of the source over time.
 
@@ -332,11 +370,11 @@ def calc_beam(
     X1: torch.Tensor,
     X2: torch.Tensor,
     rd: torch.Tensor,
-    ra: float,
-    dec: float,
+    ra: float | torch.Tensor,
+    dec: float | torch.Tensor,
     ant_diam: torch.Tensor,
-    spw_low: float,
-    spw_high: float,
+    spw_low: float | torch.Tensor,
+    spw_high: float | torch.Tensor,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Computes the beam influence on the image.
 
@@ -372,7 +410,7 @@ def calc_beam(
 
 
 @torch.compile
-def angular_distance(rd, ra, dec):
+def angular_distance(rd: torch.Tensor, ra: torch.Tensor, dec: torch.Tensor):
     """Calculates angular distance from source position
 
     Parameters

--- a/src/pyvisgen/simulation/scan.py
+++ b/src/pyvisgen/simulation/scan.py
@@ -164,7 +164,7 @@ def apply_finufft(
     lm: torch.Tensor,
     spw_low: float | torch.Tensor,
     spw_high: float | torch.Tensor,
-    finufft: CupyFinufft,
+    finufft,
 ) -> torch.Tensor:  # pragma: no cover
     if not torch.cuda.is_available():
         raise RuntimeError(

--- a/src/pyvisgen/simulation/visibility.py
+++ b/src/pyvisgen/simulation/visibility.py
@@ -619,7 +619,7 @@ def _batch_loop(
         bas_p = bas[p]
 
         int_values = torch.cat(
-            [
+            tensors=[
                 rime(
                     B,
                     bas_p,
@@ -629,10 +629,15 @@ def _batch_loop(
                 for wave_low, wave_high in zip(obs.waves_low, obs.waves_high)
             ]
         )
+
         if int_values.numel() == 0:
             continue
 
         int_values = torch.swapaxes(int_values, 0, 1)
+
+        # In case any row contains NaN
+        int_values_nans = torch.isnan(int_values).any(dim=(1, 2, 3))
+        int_values = int_values[~int_values_nans]
 
         if noisy != 0:
             noise = generate_noise(int_values.shape, obs, noisy)
@@ -641,18 +646,18 @@ def _batch_loop(
         vis_num = torch.arange(int_values.shape[0]) + 1 + vis_num.max()
 
         vis = Visibilities(
-            int_values[..., 0, 0].cpu(),  # V_11
-            int_values[..., 1, 1].cpu(),  # V_22
-            int_values[..., 0, 1].cpu(),  # V_12
-            int_values[..., 1, 0].cpu(),  # V_21
-            vis_num,
-            bas_p.baseline_nums.cpu(),
-            bas_p.u_valid.cpu(),
-            bas_p.v_valid.cpu(),
-            bas_p.w_valid.cpu(),
-            bas_p.date.cpu(),
-            torch.tensor([]),
-            torch.tensor([]),
+            V_11=int_values[..., 0, 0].cpu(),
+            V_22=int_values[..., 1, 1].cpu(),
+            V_12=int_values[..., 0, 1].cpu(),
+            V_21=int_values[..., 1, 0].cpu(),
+            num=vis_num,
+            base_num=bas_p.baseline_nums[~int_values_nans].cpu(),
+            u=bas_p.u_valid[~int_values_nans].cpu(),
+            v=bas_p.v_valid[~int_values_nans].cpu(),
+            w=bas_p.w_valid[~int_values_nans].cpu(),
+            date=bas_p.date[~int_values_nans].cpu(),
+            linear_dop=torch.tensor([]),
+            circular_dop=torch.tensor([]),
         )
 
         visibilities.add(vis)

--- a/src/pyvisgen/simulation/visibility.py
+++ b/src/pyvisgen/simulation/visibility.py
@@ -552,7 +552,7 @@ def vis_loop(
 def _batch_loop(
     batch_size: int,
     visibilities,
-    vis_num: int,
+    vis_num: torch.Tensor,
     obs,
     B: torch.Tensor,
     bas,
@@ -572,7 +572,7 @@ def _batch_loop(
         Batch size for loop over Baselines dataclass object.
     visibilities : Visibilities
         Visibilities dataclass object.
-    vis_num : int
+    vis_num : torch.Tensor
         Number of visibilities.
     obs : Observation
         Observation class object.

--- a/src/pyvisgen/simulation/visibility.py
+++ b/src/pyvisgen/simulation/visibility.py
@@ -7,7 +7,7 @@ import scipy.ndimage
 import torch
 from tqdm.auto import tqdm
 
-import pyvisgen.simulation.scan as scan
+from pyvisgen.simulation.scan import RIMEScan
 from pyvisgen.utils.batch_size import adaptive_batch_size
 from pyvisgen.utils.logging import setup_logger
 
@@ -613,25 +613,18 @@ def _batch_loop(
         postfix=f"Batch size: {batch_size}",
     )
 
+    rime = RIMEScan(ft=ft, mode=mode, obs=obs, lm=lm, rd=rd)
+
     for p in batches:
         bas_p = bas[p]
 
         int_values = torch.cat(
             [
-                scan.rime(
+                rime(
                     B,
                     bas_p,
-                    lm,
-                    rd,
-                    obs.ra,
-                    obs.dec,
-                    torch.unique(obs.array.diam),
-                    wave_low,
-                    wave_high,
-                    obs.polarization,
-                    mode=mode,
-                    corrupted=obs.corrupted,
-                    ft=ft,
+                    spw_low=wave_low,
+                    spw_high=wave_high,
                 )[None]
                 for wave_low, wave_high in zip(obs.waves_low, obs.waves_high)
             ]

--- a/src/pyvisgen/utils/logging.py
+++ b/src/pyvisgen/utils/logging.py
@@ -28,6 +28,8 @@ def setup_logger(namespace="rich", level="INFO", **kwargs):
         Rich's builtin logging handler for more information on
         allowed keyword arguments.
     """
+    logging.captureWarnings(True)
+
     FORMAT = "%(message)s"
 
     logging.basicConfig(

--- a/tests/simulation/test_scan.py
+++ b/tests/simulation/test_scan.py
@@ -91,16 +91,8 @@ def setup_test_data(device):
     }
 
 
-class TestScan:
+class TestJonesMatrices:
     """Unit tests for pyvisgen.simulation.scan module."""
-
-    @pytest.fixture
-    def rime_test_data(self, setup_test_data):
-        data = setup_test_data.copy()
-        data.pop("device")
-        data.pop("polarization")
-
-        return data
 
     def test_jinc(self, device):
         """Test the jinc function."""

--- a/tests/simulation/test_scan.py
+++ b/tests/simulation/test_scan.py
@@ -327,7 +327,7 @@ class TestRIME:
 
     def test_rime_grid_reversed(self, rime_test_data):
         """Test the complete RIME function."""
-        rime_data, obs = rime_test_data
+        *rime_data, obs = rime_test_data
         obs.polarization = None
 
         # Test with mode = "grid" (default case)
@@ -348,7 +348,7 @@ class TestRIME:
 
     @pytest.mark.skipif(not _FINUFFT_AVAIL, reason=_FINUFFT_ERROR)
     def test_rime_finufft(self, rime_test_data):
-        rime_data, obs = rime_test_data
+        *rime_data, obs = rime_test_data
         obs.polarization = None
 
         # Test with mode = "grid" (use radioft finufft)
@@ -366,7 +366,7 @@ class TestRIME:
 
     @pytest.mark.parametrize("polarization", ["linear", "circular"])
     def test_rime_grid_polarisation(self, polarization, rime_test_data):
-        rime_data, obs = rime_test_data
+        *rime_data, obs = rime_test_data
         obs.polarization = polarization
 
         # Test with mode = "grid" with polarization
@@ -381,18 +381,18 @@ class TestRIME:
         assert vis_grid_pol.dtype == torch.complex128
 
     def test_rime_grid_corrupted(self, rime_test_data):
-        rime_data, obs = rime_test_data
+        *rime_data, obs = rime_test_data
         obs.polarization = None
-        obs.corrupted = True
 
         rime = RIMEScan("default", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
-
-        # Test with corrupted=True
-        vis_corrupted = rime(
+        vis_grid = rime(
             *rime_data,
         )
 
-        vis_grid = rime(
+        obs.corrupted = True
+        rime = RIMEScan("default", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
+        # Test with corrupted=True
+        vis_corrupted = rime(
             *rime_data,
         )
 

--- a/tests/simulation/test_scan.py
+++ b/tests/simulation/test_scan.py
@@ -3,13 +3,13 @@ import torch
 
 from pyvisgen.simulation.observation import ValidBaselineSubset
 from pyvisgen.simulation.scan import (
+    RIMEScan,
     angular_distance,
     calc_beam,
     calc_feed_rotation,
     calc_fourier,
     integrate,
     jinc,
-    rime,
 )
 
 try:
@@ -278,21 +278,49 @@ class TestJonesMatrices:
             ),
         )
 
+
+class TestRIME:
+    @pytest.fixture
+    def rime_test_data(self, setup_test_data):
+        from dataclasses import dataclass
+
+        data = setup_test_data()
+        img = data["img"]
+        bas = data["bas"]
+        spw_low = data["spw_low"]
+        spw_high = data["spw_high"]
+
+        for key in ["img", "bas", "spw_low", "spw_hight"]:
+            data.pop(key)
+
+        @dataclass
+        class MockObs:
+            lm: torch.Tensor
+            rd: torch.Tensor
+            ra: torch.Tensor
+            dec: torch.Tensor
+            ant_diam: torch.Tensor
+            polarization: str
+            device: str
+            corrupted: bool
+
+        return img, bas, spw_low, spw_high, MockObs(**setup_test_data, corrupted=False)
+
     def test_rime_grid_reversed(self, rime_test_data):
         """Test the complete RIME function."""
+        rime_data, obs = rime_test_data
+        obs.polarization = None
+
         # Test with mode = "grid" (default case)
+        rime = RIMEScan("default", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
         vis_grid = rime(
-            **rime_test_data,
-            polarization=None,
-            mode="grid",
+            *rime_data,
         )
 
         # Test with mode = "grid" (reversed jones ordering)
+        rime = RIMEScan("reversed", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
         vis_grid_reversed = rime(
-            **rime_test_data,
-            polarization=None,
-            mode="grid",
-            ft="reversed",
+            *rime_data,
         )
 
         assert torch.isclose(vis_grid_reversed, vis_grid, rtol=1e-8).all()
@@ -301,27 +329,30 @@ class TestJonesMatrices:
 
     @pytest.mark.skipif(not _FINUFFT_AVAIL, reason=_FINUFFT_ERROR)
     def test_rime_finufft(self, rime_test_data):
+        rime_data, obs = rime_test_data
+        obs.polarization = None
+
         # Test with mode = "grid" (use radioft finufft)
+        rime = RIMEScan("finufft", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
         vis_grid_finufft = rime(
-            **rime_test_data,
-            polarization=None,
-            mode="grid",
-            ft="finufft",
+            *rime_data,
         )
 
+        rime = RIMEScan("reversed", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
         vis_grid_reversed = rime(
-            **rime_test_data,
-            polarization=None,
-            mode="grid",
-            ft="reversed",
+            *rime_data,
         )
 
         assert torch.isclose(vis_grid_reversed, vis_grid_finufft, rtol=1e-6).all()
 
     @pytest.mark.parametrize("polarization", ["linear", "circular"])
     def test_rime_grid_polarisation(self, polarization, rime_test_data):
+        rime_data, obs = rime_test_data
+        obs.polarization = polarization
+
         # Test with mode = "grid" with polarization
-        vis_grid_pol = rime(**rime_test_data, polarization=polarization, mode="grid")
+        rime = RIMEScan("default", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
+        vis_grid_pol = rime(*rime_data)
 
         # Check output shape, should be (baseline, 2, 2)
         expected_shape = (3, 2, 2)
@@ -331,18 +362,19 @@ class TestJonesMatrices:
         assert vis_grid_pol.dtype == torch.complex128
 
     def test_rime_grid_corrupted(self, rime_test_data):
+        rime_data, obs = rime_test_data
+        obs.polarization = None
+        obs.corrupted = True
+
+        rime = RIMEScan("default", mode="grid", obs=obs, lm=obs.lm, rd=obs.rd)
+
         # Test with corrupted=True
         vis_corrupted = rime(
-            **rime_test_data,
-            polarization=None,
-            mode="grid",
-            corrupted=True,
+            *rime_data,
         )
 
         vis_grid = rime(
-            **rime_test_data,
-            polarization=None,
-            mode="grid",
+            *rime_data,
         )
 
         expected_shape = (3, 2, 2)

--- a/tests/simulation/test_scan.py
+++ b/tests/simulation/test_scan.py
@@ -284,14 +284,19 @@ class TestRIME:
     def rime_test_data(self, setup_test_data):
         from dataclasses import dataclass
 
-        data = setup_test_data()
+        data = setup_test_data
         img = data["img"]
         bas = data["bas"]
         spw_low = data["spw_low"]
         spw_high = data["spw_high"]
+        ant_diam = data["ant_diam"]
 
-        for key in ["img", "bas", "spw_low", "spw_hight"]:
+        for key in ["img", "bas", "spw_low", "spw_high", "ant_diam"]:
             data.pop(key)
+
+        @dataclass
+        class MockArray:
+            diam: torch.Tensor
 
         @dataclass
         class MockObs:
@@ -299,12 +304,26 @@ class TestRIME:
             rd: torch.Tensor
             ra: torch.Tensor
             dec: torch.Tensor
-            ant_diam: torch.Tensor
+            array: MockArray
             polarization: str
             device: str
             corrupted: bool
+            img_size: int
+            fov: float
 
-        return img, bas, spw_low, spw_high, MockObs(**setup_test_data, corrupted=False)
+        return (
+            img,
+            bas,
+            spw_low,
+            spw_high,
+            MockObs(
+                **setup_test_data,
+                corrupted=False,
+                img_size=img.shape[-1],
+                fov=0.24,
+                array=MockArray(diam=ant_diam),
+            ),
+        )
 
     def test_rime_grid_reversed(self, rime_test_data):
         """Test the complete RIME function."""

--- a/tests/simulation/test_visibility.py
+++ b/tests/simulation/test_visibility.py
@@ -552,7 +552,8 @@ class TestBatchLoop:
     @pytest.fixture
     def mock_scan(self, mocker, int_values: torch.Tensor):
         return mocker.patch(
-            "pyvisgen.simulation.visibility.scan.rime", return_value=int_values
+            "pyvisgen.simulation.visibility.RIMEScan.default",
+            return_value=int_values,
         )
 
     def test_loop(
@@ -578,7 +579,7 @@ class TestBatchLoop:
         self, mocker, batch_loop_args: dict, empty_vis: Visibilities
     ) -> None:
         mocker.patch(
-            "pyvisgen.simulation.visibility.scan.rime",
+            "pyvisgen.simulation.visibility.RIMEScan.default",
             return_value=torch.rand([0, 2, 2]),
         )
 


### PR DESCRIPTION
This PR refactors the RIME and fixes the `finufft` ft mode.

## Changes to `pyvisgen.simulation.scan`

- Separated `rime` function into three methods of a new class `RIMEScan`
    - The class structure allows keeping constants such as `ra`, `dec`, `lm` and `rd` as class attributes that only have to be set once during `__init__`
    - Additionally, the `__init__` method also allows correctly setting up the `radioft.finufft.CupyFinufft` wrapper with simulation parameters set in `pyvisgen.simulation.observation.Observation`; this was previously hard-coded and thus not accessible through the configuration
    - `RIMEScan` is initialized *once* after which only the `__call__` method is used to compute the visibilities
    - Depending on the Fourier transform `ft` chosen when initializing `RIMEScan`, `__init__` sets one of the methods `default`, `reverse`, or `finufft` as the `ft_func` attr, which is accessed by `__call__`

- Refactored `apply_finufft` function
    - Changed reshaping of `X1` and `X2` to first permute `(1, 2, 0)`, because PyTorch memory is contiguous in C-order and the four stokes values per pixel are stored next to each other in memory. Essentially that means that we have `[p00, p01, p02, p03, p10, p11, p12, p13, ...]` and the way we previously reshaped with `(4, -1)` would only divide the array into 4 blocks in the same sequence we have above, instead of 4 blocks that contain only the pixels of one Stokes component, respectively.
    - Removed CUDA streams as they did not yield significant improvements to performance but instead sometimes lead to early stopping of the loop and thus resulting in shape mismatches of the visibility tensors
    - Changed `vis_avg.T` to `vis_avg.mT` to get rid of deprecation warnings

## Changes to `pyvisgen.simulation.visibility`
- Refactored `_batch_loop` function
    - Initialized `RIMEScan` before the actual loop:
      ```python
      rime = RIMEScan(ft=ft, mode=mode, obs=obs, lm=lm, rd=rd)
      ```
    - Updated call signature for rime since we now only need the image, valid baselines subset as, and upper and lower frequencies/wavelengths → cf. [Changes to `pyvisgen.simulation.scan`](#Changes-to-pyvisgensimulationscan)
        - New call signature:
          ```python
          rime(img=B, bas=bas_p, spw_low=wave_low, spw_high=wave_high)
          ```
    - Added a mask to filter out `nan` in `int_values`: we drop any row @ dim `0` after swapping axes (`torch.swapaxes`)
        - Just in case we ever have `nan` in our visibilities
        - With that we can ensure that only valid (and finite) values are passed to the gridder
        - The mask used to drop the `nan` is also used to drop the same rows in the uvw coordinates as well as `base_num` and `date`
        - As such, we have a `Visibilities` dataclass object that has correct dimensions in every attribute

## Changes to `pyvisgen.utils.logging`
- Capture warnings from other packges with logger

Merge after #144 and https://github.com/radionets-project/radioft/pull/31.