### PR TITLE
Fixes before 0.8

### DIFF
--- a/config/default_data_set.toml
+++ b/config/default_data_set.toml
@@ -47,4 +47,4 @@ overlap = 5
 gridder = "default"
 
 [fft]
-ft = "default"
+ft = "finufft"

--- a/docs/changes/146.bugfix.rst
+++ b/docs/changes/146.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where setting the gridder to default would trigger the fallback instead of using ``pyvisgrid.gridder`` directly

--- a/docs/changes/146.feature.rst
+++ b/docs/changes/146.feature.rst
@@ -1,0 +1,1 @@
+Added station id pairs to ValidBaselineSubset that allow making stations unavailable for observations

--- a/docs/changes/146.maintenance.rst
+++ b/docs/changes/146.maintenance.rst
@@ -1,0 +1,1 @@
+Set finufft as default in config

--- a/src/pyvisgen/_plugin_manager.py
+++ b/src/pyvisgen/_plugin_manager.py
@@ -54,6 +54,9 @@ class Manager:
                 f"with pyvisgen {__version__}, e.g. pyvisgrid.gridder from pyvisgrid "
                 "(uv pip install pyvisgrid)!"
             )
+        if name == "default":
+            return plugins["pyvisgrid.gridder"]
+
         if name not in plugins:
             raise ValueError(
                 f"Plugin '{name}' not found. Available: {list(plugins.keys())}"

--- a/src/pyvisgen/simulation/observation.py
+++ b/src/pyvisgen/simulation/observation.py
@@ -261,9 +261,9 @@ class ValidBaselineSubset:
             object containing all attributes that fall in the time
             range between ``t_start`` and ``t_stop``.
         """
-        return ValidBaselineSubset(
-            *[getattr(self, f.name).ravel() for f in fields(self)]
-        )[(self.date >= t_start) & (self.date <= t_stop)]
+        return ValidBaselineSubset(*[getattr(self, f.name) for f in fields(self)])[
+            (self.date >= t_start) & (self.date <= t_stop)
+        ]
 
     def get_unique_grid(
         self,

--- a/src/pyvisgen/simulation/observation.py
+++ b/src/pyvisgen/simulation/observation.py
@@ -237,7 +237,7 @@ class ValidBaselineSubset:
     q2_start: torch.Tensor
     q2_stop: torch.Tensor
     q2_valid: torch.Tensor
-    st_id_pairs: torch.Tensor[tuple]
+    st_id_pairs: torch.Tensor
 
     def __getitem__(self, i):
         """Returns element at index ``i`` for all fields."""

--- a/src/pyvisgen/simulation/observation.py
+++ b/src/pyvisgen/simulation/observation.py
@@ -732,6 +732,7 @@ class Observation:
             q2_start=torch.zeros(u.shape, device=self.device),
             q2_stop=torch.zeros(u.shape, device=self.device),
             q2_valid=torch.zeros(u.shape, device=self.device),
+            st_id_pairs=torch.zeros(u.shape, device=self.device),
         )
 
     def calc_baselines(self):

--- a/src/pyvisgen/simulation/observation.py
+++ b/src/pyvisgen/simulation/observation.py
@@ -121,11 +121,12 @@ class Baselines:
         )
 
         mask = (bas_reshaped.valid[:-1].bool()) & (bas_reshaped.valid[1:].bool())
-        baseline_nums = (
-            256 * (bas_reshaped.st1[:-1][mask].ravel() + 1)
-            + bas_reshaped.st2[:-1][mask].ravel()
-            + 1
-        ).to(device)
+
+        stations_1 = bas_reshaped.st1[:-1][mask].ravel()
+        stations_2 = bas_reshaped.st2[:-1][mask].ravel()
+        baseline_nums = (256 * (stations_1 + 1) + stations_2 + 1).to(device)
+
+        st_id_pairs = torch.stack([stations_1, stations_2], dim=1)
 
         u_start = bas_reshaped.u[:-1][mask].to(device)
         v_start = bas_reshaped.v[:-1][mask].to(device)
@@ -169,6 +170,7 @@ class Baselines:
             q2_start,
             q2_stop,
             q2_valid,
+            st_id_pairs,
         )
 
 
@@ -183,38 +185,39 @@ class ValidBaselineSubset:
 
     Attributes
     ----------
-    u_start : :func:`~torch.tensor`
+    u_start : :class:`~torch.Tensor`
         Start value for u coverage integration.
-    u_stop : :func:`~torch.tensor`
+    u_stop : :class:`~torch.Tensor`
         Stop value for u coverage integration.
-    u_valid : :func:`~torch.tensor`
+    u_valid : :class:`~torch.Tensor`
         Valid u values.
-    v_start : :func:`~torch.tensor`
+    v_start : :class:`~torch.Tensor`
         Start value for v coverage integration.
-    v_stop : :func:`~torch.tensor`
+    v_stop : :class:`~torch.Tensor`
         Start value for v coverage integration.
-    v_valid : :func:`~torch.tensor`
+    v_valid : :class:`~torch.Tensor`
         Valid v values.
-    w_start : :func:`~torch.tensor`
+    w_start : :class:`~torch.Tensor`
         Start value for w coverage integration.
-    w_stop : :func:`~torch.tensor`
+    w_stop : :class:`~torch.Tensor`
         Start value for w coverage integration.
-    w_valid : :func:`~torch.tensor`
+    w_valid : :class:`~torch.Tensor`
         Valid w values.
-    baseline_nums : :func:`~torch.tensor`
+    baseline_nums : :class:`~torch.Tensor`
         Numbers of baselines per time step.
-    date : :func:`~torch.tensor`
+    date : :class:`~torch.Tensor`
         Time steps of the measurement during which
         at least one baseline pair contributed to the
         measurement.
-    q1_start : :func:`~torch.tensor`
-    q1_stop : :func:`~torch.tensor`
-    q1_valid : :func:`~torch.tensor`
+    q1_start : :class:`~torch.Tensor`
+    q1_stop : :class:`~torch.Tensor`
+    q1_valid : :class:`~torch.Tensor`
         Valid parallactic angle values (first half of the pair).
-    q2_start : :func:`~torch.tensor`
-    q2_stop : :func:`~torch.tensor`
-    q2_valid : :func:`~torch.tensor`
+    q2_start : :class:`~torch.Tensor`
+    q2_stop : :class:`~torch.Tensor`
+    q2_valid : :class:`~torch.Tensor`
         Valid parallactic angle values (second half of the pair).
+    st_id_pairs : :class:`~torch.Tensor`
     """
 
     u_start: torch.Tensor
@@ -234,6 +237,7 @@ class ValidBaselineSubset:
     q2_start: torch.Tensor
     q2_stop: torch.Tensor
     q2_valid: torch.Tensor
+    st_id_pairs: torch.Tensor[tuple]
 
     def __getitem__(self, i):
         """Returns element at index ``i`` for all fields."""

--- a/src/pyvisgen/simulation/scan.py
+++ b/src/pyvisgen/simulation/scan.py
@@ -29,6 +29,31 @@ __all__ = [
 
 
 class RIMEScan:
+    """Apply the Radio Interferometry Measurement Equation (RIME) to sky images.
+
+    This class handles the calculation of visibilities from sky images using
+    either direct Fourier transforms or Non-Uniform Fast Fourier Transforms
+    (FINUFFT). Depending on the observation settings it also applies
+    telescope beam effects or feed rotation.
+
+    Parameters
+    ----------
+    ft : str
+        Fourier transform method to use ('default', 'reversed', or 'finufft').
+    mode : str
+        Observation mode, can be 'full', 'grid' or 'dense'. Dense is only suitable
+        for debugging and disables feed rotation calculation.
+    obs : :class:`~pyvisgen.simulation.Observation`
+        Observation class object containing observation parameters such as
+        the source position.
+    lm : :class:`~torch.Tensor`
+        Direction cosines (l, m) grid for the field of view.
+    rd : :class:`~torch.Tensor`
+        Right ascension and declination grid corresponding to the field of view.
+    eps : float, optional
+        Tolerance for the cuFINUFFT. Default: 1e-8.
+    """
+
     def __init__(self, ft, mode, obs, lm, rd, eps=1e-8):
         if _FINUFFT_AVAIL:
             self.cupy_finufft = CupyFinufft(
@@ -53,6 +78,24 @@ class RIMEScan:
         spw_low: torch.Tensor,
         spw_high: torch.Tensor,
     ) -> torch.Tensor:
+        """Process the input sky image to produce visibilities.
+
+        Parameters
+        ----------
+        img : :class:`~torch.Tensor`
+            Input sky image tensor.
+        bas : :class:`~pyvisgen.simulation.ValidBaselineSubset`
+            Subset of valid baselines containing uvw coordinates.
+        spw_low : :class:`~torch.Tensor`
+            Lower spectral window frequencies/wavelengths.
+        spw_high : :class:`~torch.Tensor`
+            Higher spectral window frequencies/wavelengths.
+
+        Returns
+        -------
+        :class:`~torch.Tensor`
+            Calculated complex visibilities for the given baselines.
+        """
         with torch.no_grad():
             if self.ft == "reversed":
                 img = torch.repeat_interleave(
@@ -78,6 +121,29 @@ class RIMEScan:
         spw_low: torch.Tensor,
         spw_high: torch.Tensor,
     ) -> torch.Tensor:
+        """Evaluate default the RIME Jones chain.
+
+        Calculates direct Fourier kernels, applies feed rotation and
+        beam effects, and integrates over the image.
+
+        Parameters
+        ----------
+        X1 : :class:`~torch.Tensor`
+            Sky tensor for the lower spectral window.
+        X2 : :class:`~torch.Tensor`
+            Sky tensor for the higher spectral window.
+        bas : :class:`~pyvisgen.simulation.ValidBaselineSubset`
+            Subset of valid baselines containing uvw coordinates.
+        spw_low : :class:`~torch.Tensor`
+            Lower spectral window frequencies/wavelengths.
+        spw_high : :class:`~torch.Tensor`
+            Higher spectral window frequencies/wavelengths.
+
+        Returns
+        -------
+        :class:`~torch.Tensor`
+            Visibilities calculated with the default RIME Jones chain.
+        """
         X1, X2 = calc_fourier(X1, X2, bas, self.lm, spw_low, spw_high)
 
         if self.polarization and self.mode != "dense":
@@ -107,6 +173,29 @@ class RIMEScan:
         spw_low: torch.Tensor,
         spw_high: torch.Tensor,
     ) -> torch.Tensor:
+        """Compute the default RIME Jones chain in reversed order.
+
+        Applies feed rotation and primary beam effects before calculating
+        Fourier kernels and integrating.
+
+        Parameters
+        ----------
+        X1 : :class:`~torch.Tensor`
+            Sky tensor for the lower spectral window.
+        X2 : :class:`~torch.Tensor`
+            Sky tensor for the higher spectral window.
+        bas : :class:`~pyvisgen.simulation.ValidBaselineSubset`
+            Subset of valid baselines containing uvw coordinates.
+        spw_low : :class:`~torch.Tensor`
+            Lower spectral window frequencies/wavelengths.
+        spw_high : :class:`~torch.Tensor`
+            Higher spectral window frequencies/wavelengths.
+
+        Returns
+        -------
+        :class:`~torch.Tensor`
+            Visibilities calculated with the reversed RIME Jones chain.
+        """
         if self.polarization and self.mode != "dense":
             X1, X2 = calc_feed_rotation(X1, X2, bas, self.polarization)
 
@@ -135,6 +224,34 @@ class RIMEScan:
         spw_low: torch.Tensor,
         spw_high: torch.Tensor,
     ) -> torch.Tensor:
+        """Evaluate RIME using cuFINUFFT.
+
+        Utilizes GPU-accelerated non-uniform FFTs for
+        faster visibility computation.
+
+        Parameters
+        ----------
+        X1 : :class:`~torch.Tensor`
+            Sky tensor for the lower spectral window.
+        X2 : :class:`~torch.Tensor`
+            Sky tensor for the higher spectral window.
+        bas : :class:`~pyvisgen.simulation.ValidBaselineSubset`
+            Subset of valid baselines containing uvw coordinates.
+        spw_low : :class:`~torch.Tensor`
+            Lower spectral window frequencies/wavelengths.
+        spw_high : :class:`~torch.Tensor`
+            Higher spectral window frequencies/wavelengths.
+
+        Returns
+        -------
+        :class:`~torch.Tensor`
+            Visibilities computed with cuFINUFFT.
+
+        Raises
+        ------
+        RuntimeError
+            If cuFINUFFT package is not successfully loaded or available.
+        """
         if not _FINUFFT_AVAIL:
             raise RuntimeError(_FINUFFT_ERROR)
 
@@ -166,6 +283,34 @@ def apply_finufft(
     spw_high: float | torch.Tensor,
     finufft,
 ) -> torch.Tensor:  # pragma: no cover
+    """Apply cuFINUFFT to input images to compute visibilities.
+
+    Parameters
+    ----------
+    X1 : :class:`~torch.Tensor`
+        Sky tensor for the lower spectral window.
+    X2 : :class:`~torch.Tensor`
+        Sky tensor for the higher spectral window.
+    bas : :class:`~pyvisgen.simulation.ValidBaselineSubset`
+        Subset of valid baselines containing uvw coordinates.
+    spw_low : :class:`~torch.Tensor`
+        Lower spectral window frequencies/wavelengths.
+    spw_high : :class:`~torch.Tensor`
+        Higher spectral window frequencies/wavelengths.
+    finufft : :class:`~radioft.finufft.finufft.CupyFinufft`
+        Initialized :class:`~radioft.finufft.finufft.CupyFinufft` object
+        to be used to compute the visibilities.
+
+    Returns
+    -------
+    :class:`~torch.Tensor`
+        Visibilities computed with cuFINUFFT.
+
+    Raises
+    ------
+    RuntimeError
+        If CUDA is not available.
+    """
     if not torch.cuda.is_available():
         raise RuntimeError(
             "CUDA is not available. Finufft backend requires a CUDA-enabled GPU to run."

--- a/tests/simulation/conftest.py
+++ b/tests/simulation/conftest.py
@@ -48,6 +48,9 @@ def subset_data(device) -> dict[str, torch.Tensor]:
     time = Time(torch.linspace(0, 1000, size) / (60 * 60 * 24), format="mjd").jd
     date = (torch.from_numpy(time) / 2).to(device)
 
+    baseline_nums = torch.arange(size, device=dev)
+    st_id_pairs = torch.stack([baseline_nums, baseline_nums], dim=1)
+
     return {
         "u_start": torch.rand(size, device=dev),
         "u_stop": torch.rand(size, device=dev),
@@ -58,7 +61,7 @@ def subset_data(device) -> dict[str, torch.Tensor]:
         "w_start": torch.rand(size, device=dev),
         "w_stop": torch.rand(size, device=dev),
         "w_valid": torch.rand(size, device=dev),
-        "baseline_nums": torch.arange(size, device=dev),
+        "baseline_nums": baseline_nums,
         "date": date,
         "q1_start": torch.rand(size, device=dev),
         "q1_stop": torch.rand(size, device=dev),
@@ -66,6 +69,7 @@ def subset_data(device) -> dict[str, torch.Tensor]:
         "q2_start": torch.rand(size, device=dev),
         "q2_stop": torch.rand(size, device=dev),
         "q2_valid": torch.rand(size, device=dev),
+        "st_id_pairs": st_id_pairs,
     }
 
 

--- a/tests/simulation/test_observation.py
+++ b/tests/simulation/test_observation.py
@@ -79,7 +79,7 @@ class TestValidBaselineSubset:
         assert isinstance(subset_item, ValidBaselineSubset)
 
         for f in fields(ValidBaselineSubset):
-            assert getattr(subset_item, f.name) == getattr(subset, f.name)[idx]
+            assert (getattr(subset_item, f.name) == getattr(subset, f.name)[idx]).all()
 
     def test_get_slice(self, subset: ValidBaselineSubset) -> None:
         subset_items = subset[2:-2]

--- a/tests/simulation/test_scan.py
+++ b/tests/simulation/test_scan.py
@@ -57,6 +57,7 @@ def setup_test_data(device):
         q2_start=torch.Tensor([]),
         q2_stop=torch.Tensor([]),
         q2_valid=torch.tensor([0.15], device=device),  # q2
+        st_id_pairs=torch.zeros(1, device=device),
     )
 
     # Sky position


### PR DESCRIPTION
Minor fixes before the 0.8 release.

- Added docstrings to the `RIMEScan` class
- Fixed gridding plugin default handling 
- Set finufft as default ft in config
- Added station id pairs to `ValidBaselineSubset`