### PR TITLE
feat: add 'obs' group with ra/dec, layout keys to uvh5 files

### DIFF
--- a/docs/changes/154.feature.rst
+++ b/docs/changes/154.feature.rst
@@ -1,0 +1,1 @@
+Added a new group ``obs`` containing ``ra``/``dec`` and ``layout`` to UVH5 files. 

--- a/docs/changes/154.feature.rst
+++ b/docs/changes/154.feature.rst
@@ -1,1 +1,1 @@
-Added a new group ``obs`` containing ``ra``/``dec`` and ``layout`` to UVH5 files. 
+Added a new group ``obs`` containing ``ra``/``dec`` and ``layout`` to UVH5 files.

--- a/src/pyvisgen/io/datawriters.py
+++ b/src/pyvisgen/io/datawriters.py
@@ -533,6 +533,11 @@ class UVH5Writer(DataWriter):
             times = self.__to_numpy(vis_data.date)
             f.create_dataset("times", data=times)
 
+            obs_grp = f.create_group("obs")
+            obs_grp.create_dataset("ra", data=self.__to_numpy(obs.ra))
+            obs_grp.create_dataset("dec", data=self.__to_numpy(obs.dec))
+            obs_grp.create_dataset("layout", data=obs.layout)
+
             if sky is not None:
                 sky_grp = f.create_group("sky")
                 sky_grp.create_dataset("SI", data=self.__to_numpy(sky))

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -193,6 +193,9 @@ def uvh5_obs() -> SimpleNamespace:
         ref_frequency=torch.tensor(15.7e9),
         frequency_offsets=torch.tensor([0.0, 1.0e6]),
         bandwidths=torch.tensor([1.0e6, 1.0e6]),
+        ra=torch.tensor([42]),
+        dec=torch.tensor([180]),
+        layout="meerkat",
     )
 
 


### PR DESCRIPTION
just a small PR to add ra/dec (and also the layout name) to comply with new ra/dec requirements in the Gridder class of pyvisgrid