### PR TITLE
feat: add ArrayDisplay class

### DIFF
--- a/docs/changes/159.feature.rst
+++ b/docs/changes/159.feature.rst
@@ -1,0 +1,1 @@
+Added :class:`~pyvisgen.layouts.ArrayDisplay` class that allows visualizing any :class:`~pyvisgen.layouts.Stations` object.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ tests = [
   "pytest >= 7.0",
   "restructuredtext-lint",
   "pytest-mock>=3.15.1",
+  "cmasher>=1.9.2",
 ]
 
 [build-system]

--- a/src/pyvisgen/exceptions.py
+++ b/src/pyvisgen/exceptions.py
@@ -1,0 +1,6 @@
+class OptionalDependencyMissing(ModuleNotFoundError):
+    def __init__(self, dependency):
+        exc_msg = "To use this functionality, you need to install pyvisgen "
+        exc_msg += f"with the [{dependency}] optional dependency"
+
+        super().__init__(exc_msg)

--- a/src/pyvisgen/layouts/__init__.py
+++ b/src/pyvisgen/layouts/__init__.py
@@ -1,6 +1,8 @@
+from .disp import ArrayDisplay
 from .layouts import Stations, get_array_layout, get_array_names
 
 __all__ = [
+    "ArrayDisplay",
     "Stations",
     "get_array_layout",
     "get_array_names",

--- a/src/pyvisgen/layouts/disp.py
+++ b/src/pyvisgen/layouts/disp.py
@@ -306,8 +306,8 @@ class ArrayDisplay:
         if step <= 0 or not np.isfinite(step):
             return 1.0
 
-        exponent = np.floor(np.log10(step))
-        _fraction = step / 10**exponent
+        exp = np.floor(np.log10(step))
+        _fraction = step / 10**exp
 
         if _fraction <= 1:
             fraction = 1
@@ -318,7 +318,7 @@ class ArrayDisplay:
         else:
             fraction = 10
 
-        return fraction * 10**exponent
+        return fraction * 10**exp
 
     def _pad_limits(self, padding_fraction: float = 0.12) -> None:
         xmin = np.nanmin(self.x)
@@ -330,7 +330,7 @@ class ArrayDisplay:
         yspan = ymax - ymin
         span = max(xspan, yspan).value
 
-        if span == 0:
+        if span == 0:  # pragma: no cover
             span = 1.0
 
         xmid = 0.5 * (xmin + xmax).value

--- a/src/pyvisgen/layouts/disp.py
+++ b/src/pyvisgen/layouts/disp.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+from itertools import cycle
+from typing import TYPE_CHECKING
+
+import astropy.units as u
+import numpy as np
+from astropy.coordinates import ITRS, AltAz, EarthLocation, SkyCoord
+
+from ..exceptions import OptionalDependencyMissing
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+
+__all__ = ["ArrayDisplay"]
+
+
+def _mean_geodetic_reference(locations: EarthLocation):
+    lon = locations.lon.to_value(u.rad)
+    lat = locations.lat.to_value(u.rad)
+    height = locations.height.to_value(u.m)
+
+    mean_lon = np.arctan2(np.mean(np.sin(lon)), np.mean(np.cos(lon))) * u.rad
+    mean_lat = np.mean(lat) * u.rad
+    mean_height = np.mean(height) * u.m
+
+    return EarthLocation.from_geodetic(
+        lon=mean_lon,
+        lat=mean_lat,
+        height=mean_height,
+    )
+
+
+def _earthlocation_to_enu(
+    locations: EarthLocation,
+    reference: EarthLocation | None = None,
+):
+    if reference is None:
+        reference = _mean_geodetic_reference(locations)
+
+    tel_cart = locations.get_itrs().cartesian
+    ref_cart = reference.get_itrs().cartesian
+
+    local_itrs = ITRS(
+        tel_cart - ref_cart,
+        location=reference,
+    )
+
+    local_altaz = local_itrs.transform_to(AltAz(location=reference))
+
+    return local_altaz.cartesian, reference
+
+
+def _earthlocation_deg_offsets(
+    locations: EarthLocation,
+    reference: EarthLocation,
+) -> tuple[u.Quantity, u.Quantity]:
+    ref = SkyCoord(ra=reference.lon, dec=reference.lat, frame="icrs")
+    loc = SkyCoord(ra=locations.lon, dec=locations.lat, frame="icrs")
+
+    sep = ref.separation(loc)
+    pa = ref.position_angle(loc)
+
+    return (sep * np.sin(pa)).to(u.deg), (sep * np.cos(pa)).to(u.deg)
+
+
+class ArrayDisplay:
+    """Display a top-down view of any given :class:`~pyvisgen.layouts.Stations`
+    object.
+
+    Per default, `ArrayDisplay` will scale the unit automatically
+    and change from Northing/Easting in km to lon/lat in deg if the
+    distance between two telescopes/antennas is more than 100 km. The plot will be
+    autoscaled but can be zoomed even further on the array if ``zoomed`` is
+    set to ``True``.
+
+    Parameters
+    ----------
+    stations : :class:`~pyvisgen.layouts.Stations`
+        pyvisgen Stations object containing coordinates and
+        antenna parameters.
+    axes : :class:`~matplotlib.axes.Axes` or None, optional
+        matplotlib axes to plot on. If ``None``, will use current
+        axes using matplotlib pyplots :func:`~matplotlib.pyplot.gca`
+        function. Default: ``None``
+    title : str or None, optional
+        Optional title for the plot. Default: ``None``
+    unit : str, optional
+        Unit for the axes. Can be `m`, `km`, `deg`, or `auto`.
+        If set to `auto`, `ArrayDisplay` will change the unit automatically
+        according to the threshold set in ``deg_km_thresh``.
+        Default: ``"auto"``
+    deg_km_thresh : float, optional
+        Threshold that determines when the `ArrayDisplay` switches from
+        km to deg. Default: ``100.0``
+    reference_location : EarthLocation or None, optional
+        Reference location for which the relative positions will
+        be calculated. Ideally this is the array center. If set to
+        ``None``, the center will be computed automatically.
+        Default: ``None``
+    zoomed : bool, optional
+        Whether to zoom further onto the array. Per default the plot
+        is autoscaled (limited by the radial grid). Depending on the array,
+        zooming further in may be desirable. Default: ``False``
+    padding_fraction : float, optional
+        Border padding for the zoomed plot. Default: ``0.12``
+    marker_type : str, optional
+        Either ``"fixed"`` or ``"diameter"``. Whether to have a
+        `fixed` marker size for each telescope/antenna or a `diameter`-scaled size.
+        Default: ``"fixed"``
+    marker_size : float, optional
+        Scatter plot marker size. If `marker_type` is set to `diameter`, `marker_size`
+        will be the baseline for the scaled markers. Default: ``20.0``
+    diameter_scale : float, optional
+        Additional scaling factor for diameter-scaled markers. Default: ``1.0``
+    marker_color : str | None, optional
+        Scatter plot marker color. If set to ``None``, the color will selected
+        automatically from the current matplotlib rcParams. Default: ``None``
+    """
+
+    def __init__(
+        self,
+        stations,
+        axes: Axes | None = None,
+        title: str | None = None,
+        unit: str = "auto",
+        deg_km_thresh: float = 100.0,
+        reference_location: EarthLocation | None = None,
+        zoomed: bool = False,
+        padding_fraction: float = 0.12,
+        marker_type: str = "fixed",
+        marker_size: float = 20.0,
+        diameter_scale: float = 1.0,
+        marker_color: str | None = None,
+    ) -> None:
+        try:
+            import matplotlib.pyplot as plt
+        except ModuleNotFoundError as e:
+            raise OptionalDependencyMissing("plot") from e
+
+        self.stations = stations
+        self.axes = axes or plt.gca()
+        self.unit = unit
+        self.deg_km_thresh = deg_km_thresh
+
+        self.marker_type = marker_type
+        self.marker_size = marker_size
+        self.diameter_scale = diameter_scale
+
+        self.marker_color = marker_color
+
+        self.stations_el = EarthLocation.from_geocentric(
+            stations.x,
+            stations.y,
+            stations.z,
+            unit="m",
+        )
+
+        self.st_coords, self.reference = _earthlocation_to_enu(
+            self.stations_el, reference=reference_location
+        )
+
+        self.max_radius_km = np.nanmax(
+            np.hypot(self.st_coords.x.to_value("km"), self.st_coords.y.to_value("km"))
+        )
+
+        self._set_unit()
+        self._add_radial_grid()
+
+        self._add_antennas()
+        self._labels = []
+        self.axes.set_aspect(1.0)
+        self.axes.set(
+            xlabel=f"{self.xlabel} / {self.axis_unit_label}",
+            ylabel=f"{self.ylabel} / {self.axis_unit_label}",
+            title=title,
+        )
+
+        if zoomed:
+            self._pad_limits(padding_fraction)
+        else:
+            self.axes.autoscale_view()
+
+    def _set_unit(self) -> None:
+        if self.unit == "auto":
+            self.display_unit = (
+                "deg" if self.max_radius_km > self.deg_km_thresh else "km"
+            )
+        else:
+            self.display_unit = self.unit
+
+        if self.display_unit == "deg":
+            self.x, self.y = _earthlocation_deg_offsets(
+                self.stations_el, self.reference
+            )
+            self.z = self.st_coords.z
+            self.axis_unit_label = "deg"
+            self.r = self.stations.diam
+            self.xlabel = "Approx. Rel. Longitude"
+            self.ylabel = "Approx. Rel. Latitude"
+        elif self.display_unit == "km":
+            self.x = self.st_coords.y.to(u.km)  # Easting
+            self.y = self.st_coords.x.to(u.km)  # Northing
+            self.z = self.st_coords.z.to(u.km)
+            self.r = self.stations.diam
+            self.axis_unit_label = "km"
+            self.xlabel = "Easting"
+            self.ylabel = "Northing"
+        else:
+            self.x = self.st_coords.y  # Easting
+            self.y = self.st_coords.x  # Northing
+            self.z = self.st_coords.z
+            self.r = self.stations.diam
+            self.axis_unit_label = "m"
+            self.grid_unit_label = "m"
+            self.xlabel = "Easting"
+            self.ylabel = "Northing"
+
+    def _dish_marker_sizes(self) -> float:
+        diam_m = u.Quantity(self.stations.diam, u.m).to_value(u.m)
+
+        if np.any(~np.isfinite(diam_m)) or np.any(diam_m <= 0):
+            raise ValueError("station diameters must be finite and > 0")
+
+        min_diam = np.min(diam_m)
+
+        self.diameter_factor = 1.0 + (diam_m / min_diam - 1.0) * self.diameter_scale
+
+        if np.any(self.diameter_factor <= 0):
+            raise ValueError("chosen diameter_scale creates non-positive marker sizes")
+
+        return self.marker_size * self.diameter_factor**2
+
+    def _add_antennas(self) -> None:
+        from matplotlib.pyplot import rcParams
+
+        x_plot = np.asarray(self.x.value)
+        y_plot = np.asarray(self.y.value)
+
+        self.axes.update_datalim(np.column_stack([x_plot, y_plot]))
+
+        if self.marker_type == "fixed":
+            self.marker_sizes = np.full_like(x_plot, self.marker_size)
+
+        elif self.marker_type == "diameter":
+            self.marker_sizes = self._dish_marker_sizes()
+
+        else:
+            raise ValueError("marker_type must be either 'fixed' or 'diameter'")
+
+        if not self.marker_color:
+            color_cycle = cycle(rcParams["axes.prop_cycle"].by_key()["color"])
+            self.marker_color = next(color_cycle)
+
+        self.antennas = self.axes.scatter(
+            x_plot,
+            y_plot,
+            s=self.marker_sizes,
+            c=self.marker_color,
+            alpha=0.7,
+            linewidths=2.0,
+            zorder=3,
+        )
+
+    def _add_radial_grid(
+        self,
+        *,
+        center=(0.0, 0.0),
+        color="0.85",
+        alpha=0.45,
+        linestyle="dotted",
+        linewidth=2.5,
+    ) -> None:
+        from matplotlib.collections import PatchCollection
+        from matplotlib.patches import Circle
+
+        max_radius = np.nanmax(np.hypot(self.x - center[0], self.y - center[1])).value
+        step = self._grid_step(max_radius / 6.0)
+
+        if step <= 0:
+            return None
+
+        max_grid_radius = np.ceil(max_radius / step) * step
+        radii = np.arange(step, max_grid_radius + 0.5 * step, step)
+
+        circle_patches = PatchCollection(
+            [
+                Circle(
+                    xy=center,
+                    radius=r,
+                    fill=False,
+                )
+                for r in radii
+            ],
+            color=color,
+            ls=linestyle,
+            fc="none",
+            lw=linewidth,
+            alpha=alpha,
+        )
+
+        self.axes.add_collection(circle_patches)
+
+    @staticmethod
+    def _grid_step(step) -> float:
+        if step <= 0 or not np.isfinite(step):
+            return 1.0
+
+        exponent = np.floor(np.log10(step))
+        _fraction = step / 10**exponent
+
+        if _fraction <= 1:
+            fraction = 1
+        elif _fraction <= 2:
+            fraction = 2
+        elif _fraction <= 5:
+            fraction = 5
+        else:
+            fraction = 10
+
+        return fraction * 10**exponent
+
+    def _pad_limits(self, padding_fraction: float = 0.12) -> None:
+        xmin = np.nanmin(self.x)
+        xmax = np.nanmax(self.x)
+        ymin = np.nanmin(self.y)
+        ymax = np.nanmax(self.y)
+
+        xspan = xmax - xmin
+        yspan = ymax - ymin
+        span = max(xspan, yspan).value
+
+        if span == 0:
+            span = 1.0
+
+        xmid = 0.5 * (xmin + xmax).value
+        ymid = 0.5 * (ymin + ymax).value
+
+        half = 0.5 * span * (1.0 + padding_fraction)
+
+        self.axes.set_xlim(xmid - half, xmid + half)
+        self.axes.set_ylim(ymid - half, ymid + half)
+
+    def add_labels(self, ids: bool = False, pad_points: float = 2.0, **kwargs):
+        """Add telescope/antenna names or ids to the scatter points.
+
+        Parameters
+        ----------
+        ids : bool, optional
+            If ``True``, use station ids (0, ..., N) instead of names.
+            May be useful for denser arrays. Default: ``False``
+        pad_points : float, optional
+            Additional padding, if required, e.g. for different marker linewidths.
+            Default: ``2.0``
+        **kwargs
+            Extra arguments to :meth:`~matplotlib.axes.Axes.annotate``. Refer to
+            the matplotlib documentation for a full list of all possible arguments.
+
+        Notes
+        -----
+        For very dense arrays such as the DSA-2000, the labels will overlap
+        and not be legible.
+        """
+        px = self.x.value
+        py = self.y.value
+
+        marker_radius_points = 0.5 * np.sqrt(self.marker_sizes)
+
+        labels = (
+            self.stations.st_name
+            if not ids
+            else self.stations.st_num.numpy().astype(int)
+        )
+
+        annotate_kwargs = dict(
+            fontsize=8,
+            clip_on=True,
+            ha="center",
+            va="top",
+            zorder=4,
+        )
+        annotate_kwargs.update(**kwargs)
+
+        for label, x, y, r_pt in zip(
+            labels,
+            px,
+            py,
+            marker_radius_points,
+        ):
+            lab = self.axes.annotate(
+                label,
+                xy=(x, y),
+                xycoords="data",
+                xytext=(0, -(r_pt + pad_points)),
+                textcoords="offset points",
+                **annotate_kwargs,  # ty:ignore[invalid-argument-type]
+            )
+            self._labels.append(lab)
+
+    def remove_labels(self):
+        """Remove labels set by the `add_labels` method."""
+        for lab in self._labels:
+            lab.remove()
+        self._labels = []

--- a/src/pyvisgen/layouts/disp.py
+++ b/src/pyvisgen/layouts/disp.py
@@ -184,7 +184,11 @@ class ArrayDisplay:
     def _set_unit(self) -> None:
         if self.unit == "auto":
             self.display_unit = (
-                "deg" if self.max_radius_km > self.deg_km_thresh else "km"
+                "deg"
+                if self.max_radius_km > self.deg_km_thresh
+                else "km"
+                if self.max_radius_km > 1
+                else "m"
             )
         else:
             self.display_unit = self.unit
@@ -194,29 +198,25 @@ class ArrayDisplay:
                 self.stations_el, self.reference
             )
             self.z = self.st_coords.z
-            self.axis_unit_label = "deg"
+            self.axis_unit_label = self.display_unit
             self.r = self.stations.diam
             self.xlabel = "Approx. Rel. Longitude"
             self.ylabel = "Approx. Rel. Latitude"
-        elif self.display_unit == "km":
-            self.x = self.st_coords.y.to(u.km)  # Easting
-            self.y = self.st_coords.x.to(u.km)  # Northing
-            self.z = self.st_coords.z.to(u.km)
+        elif self.display_unit in {"m", "km"}:
+            self.x = self.st_coords.y.to(self.display_unit)  # Easting
+            self.y = self.st_coords.x.to(self.display_unit)  # Northing
+            self.z = self.st_coords.z.to(self.display_unit)
             self.r = self.stations.diam
-            self.axis_unit_label = "km"
+            self.axis_unit_label = self.display_unit
             self.xlabel = "Easting"
             self.ylabel = "Northing"
         else:
-            self.x = self.st_coords.y  # Easting
-            self.y = self.st_coords.x  # Northing
-            self.z = self.st_coords.z
-            self.r = self.stations.diam
-            self.axis_unit_label = "m"
-            self.grid_unit_label = "m"
-            self.xlabel = "Easting"
-            self.ylabel = "Northing"
+            raise ValueError(
+                f"unit {self.display_unit!r} is unknown. Choose one of 'm', "
+                "'km', or 'deg'"
+            )
 
-    def _dish_marker_sizes(self) -> float:
+    def _dish_marker_sizes(self) -> np.ndarray:
         diam_m = u.Quantity(self.stations.diam, u.m).to_value(u.m)
 
         if np.any(~np.isfinite(diam_m)) or np.any(diam_m <= 0):

--- a/src/pyvisgen/layouts/layouts.py
+++ b/src/pyvisgen/layouts/layouts.py
@@ -8,6 +8,8 @@ from astropy.coordinates import EarthLocation
 
 from pyvisgen.utils.logging import setup_logger
 
+from .disp import ArrayDisplay
+
 LOGGER = setup_logger(namespace=__name__)
 
 __all__ = ["Stations", "get_array_layout", "get_array_names"]
@@ -41,6 +43,7 @@ class Stations:
         Altitude of the antennas.
     """
 
+    st_name: list[str | int]
     st_num: list[int]
     x: list[float]
     y: list[float]
@@ -67,11 +70,14 @@ class Stations:
         """
         return Stations(*[getattr(self, f.name)[i] for f in fields(self)])
 
+    def peek(self, **kwargs):
+        return ArrayDisplay(self, **kwargs)
+
 
 def get_array_layout(
     array_layout: str | Path | pd.DataFrame,
     writer: bool = False,
-) -> Stations:
+) -> Stations | pd.DataFrame:
     r"""Reads a telescope layout txt file and converts it
     into a dataclass. Also allows a DataFrame to be passed
     that is then converted into a dataclass object. This
@@ -154,7 +160,7 @@ def get_array_layout(
     # swap axes for easy conversion into stations object
     tensor = tensor.swapaxes(0, 1)
 
-    stations = Stations(*tensor)
+    stations = Stations(array["station_name"], *tensor)
 
     if writer:
         return array

--- a/tests/layouts/conftest.py
+++ b/tests/layouts/conftest.py
@@ -10,11 +10,11 @@ def params() -> dict:
     rng = np.random.default_rng(42)
 
     params = dict(
-        st_name=np.arange(10),
+        st_name=np.asarray(["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]),
         st_num=np.arange(10),
-        x=rng.uniform(size=(10)),
-        y=rng.uniform(size=(10)),
-        z=rng.uniform(size=(10)),
+        x=rng.uniform(size=(10)) * 1e5,
+        y=rng.uniform(size=(10)) * 1e5,
+        z=rng.uniform(size=(10)) * 1e5,
         diam=np.full(shape=(10), fill_value=5),
         el_low=np.full(shape=(10), fill_value=15),
         el_high=np.full(shape=(10), fill_value=85),
@@ -25,7 +25,7 @@ def params() -> dict:
     return params
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def mock_stations(params) -> SimpleNamespace:
     return SimpleNamespace(**params)
 

--- a/tests/layouts/conftest.py
+++ b/tests/layouts/conftest.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from astropy.coordinates import EarthLocation
+
+
+@pytest.fixture
+def params() -> dict:
+    rng = np.random.default_rng(42)
+
+    params = dict(
+        st_name=np.arange(10),
+        st_num=np.arange(10),
+        x=rng.uniform(size=(10)),
+        y=rng.uniform(size=(10)),
+        z=rng.uniform(size=(10)),
+        diam=np.full(shape=(10), fill_value=5),
+        el_low=np.full(shape=(10), fill_value=15),
+        el_high=np.full(shape=(10), fill_value=85),
+        altitude=rng.uniform(1e2, 8e3, size=(10)),
+        sefd=np.full(shape=(10), fill_value=100),
+    )
+
+    return params
+
+
+@pytest.fixture
+def mock_stations(params) -> SimpleNamespace:
+    return SimpleNamespace(**params)
+
+
+@pytest.fixture
+def mock_locations(mock_stations):
+    return EarthLocation(mock_stations.x, mock_stations.y, mock_stations.z, unit="m")

--- a/tests/layouts/test_disp.py
+++ b/tests/layouts/test_disp.py
@@ -1,3 +1,5 @@
+import sys
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -28,12 +30,28 @@ class TestArrayDisplay:
         for attr in attrs:
             assert hasattr(disp, attr)
 
+    def test_init_missing_matplotlib_dependency_raises(
+        self, monkeypatch, mock_stations
+    ):
+        from pyvisgen.exceptions import OptionalDependencyMissing
+
+        stations = mock_stations
+
+        monkeypatch.setitem(sys.modules, "matplotlib", None)
+        monkeypatch.setitem(sys.modules, "matplotlib.pyplot", None)
+
+        with pytest.raises(
+            OptionalDependencyMissing,
+            match=r"you need to install pyvisgen with the \[plot\]",
+        ):
+            ArrayDisplay(stations)
+
     def test_set_unit_auto_deg(self, mocker, mock_stations):
         stations = mock_stations
 
-        stations.x *= 1e6
-        stations.y *= 1e6
-        stations.z *= 1e6
+        stations.x *= 1e2
+        stations.y *= 1e2
+        stations.z *= 1e2
 
         mocker.patch.object(ArrayDisplay, "_add_radial_grid")
         mocker.patch.object(ArrayDisplay, "_add_antennas")
@@ -45,10 +63,6 @@ class TestArrayDisplay:
     def test_set_unit_auto_km(self, mocker, mock_stations):
         stations = mock_stations
 
-        stations.x *= 1e3
-        stations.y *= 1e3
-        stations.z *= 1e3
-
         mocker.patch.object(ArrayDisplay, "_add_radial_grid")
         mocker.patch.object(ArrayDisplay, "_add_antennas")
 
@@ -58,6 +72,10 @@ class TestArrayDisplay:
 
     def test_set_unit_auto_m(self, mocker, mock_stations):
         stations = mock_stations
+
+        stations.x /= 1e6
+        stations.y /= 1e6
+        stations.z /= 1e6
 
         mocker.patch.object(ArrayDisplay, "_add_radial_grid")
         mocker.patch.object(ArrayDisplay, "_add_antennas")
@@ -144,6 +162,14 @@ class TestArrayDisplay:
 
         assert disp.marker_color == marker_color
 
+    def test_add_antenna_raises(self, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+
+        with pytest.raises(ValueError, match="marker_type must be either"):
+            ArrayDisplay(stations, marker_type="invalid")
+
     @pytest.mark.parametrize("diam", [np.nan, -1])
     def test_dish_marker_sizes_raises_non_finite(self, diam, mocker, mock_stations):
         stations = mock_stations
@@ -216,7 +242,7 @@ class TestArrayDisplay:
                 self.fig, self.axes = plt.subplots()
 
             def _grid_step(self, val):
-                return -step  # negative value should be invalid
+                return step
 
         disp = MockArrayDisplay()
         assert len(disp.axes.collections) == 0
@@ -225,3 +251,74 @@ class TestArrayDisplay:
         assert len(disp.axes.collections) == 0
 
         plt.close(disp.fig)
+
+    @pytest.mark.parametrize(
+        "step,expected",
+        [
+            (-1.0, 1.0),
+            (0.0, 1.0),
+            (1.0, 1.0),
+            (2.0, 2.0),
+            (3.0, 5.0),
+            (6.0, 10.0),
+            (10.0, 10.0),
+        ],
+    )
+    def test_grid_step(self, step, expected):
+        assert ArrayDisplay._grid_step(step) == expected
+
+    def test_pad_limits(self, mock_stations):
+        stations = mock_stations
+
+        plt.clf()
+        disp1 = ArrayDisplay(stations, zoomed=True)
+        xlim1 = disp1.axes.get_xlim()
+        ylim1 = disp1.axes.get_ylim()
+
+        # Default (un-zoomed) plot limits should be larger
+        plt.clf()
+        disp2 = ArrayDisplay(stations, zoomed=False)
+        xlim2 = disp2.axes.get_xlim()
+        ylim2 = disp2.axes.get_ylim()
+
+        assert np.abs(xlim1[0]) < np.abs(xlim2[0])
+        assert np.abs(xlim1[1]) < np.abs(xlim2[1])
+        assert np.abs(ylim1[0]) < np.abs(ylim2[0])
+        assert np.abs(ylim1[1]) < np.abs(ylim2[1])
+
+    def test_add_labels(self, mock_stations):
+        stations = mock_stations
+
+        disp = ArrayDisplay(stations)
+        assert len(disp._labels) == 0
+
+        disp.add_labels()
+        assert len(disp._labels) == len(stations.x)
+        assert disp._labels[0].get_text() == "a"
+
+    def test_add_labels_ids(self, mock_stations):
+        import torch
+
+        stations = mock_stations
+
+        # real Stations object contains tensors
+        stations.st_num = torch.from_numpy(stations.st_num)
+
+        disp = ArrayDisplay(stations)
+        assert len(disp._labels) == 0
+
+        disp.add_labels(ids=True)
+        assert len(disp._labels) == len(stations.x)
+        assert disp._labels[0].get_text() == "0"
+
+    def test_remove_labels(self, mock_stations):
+        stations = mock_stations
+
+        disp = ArrayDisplay(stations)
+        assert len(disp._labels) == 0
+
+        disp.add_labels()
+        assert len(disp._labels) == len(stations.x)
+
+        disp.remove_labels()
+        assert len(disp._labels) == 0

--- a/tests/layouts/test_disp.py
+++ b/tests/layouts/test_disp.py
@@ -1,0 +1,227 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import PatchCollection, PathCollection
+
+from pyvisgen.layouts import ArrayDisplay
+
+
+class TestArrayDisplay:
+    def test_set_unit(self, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        disp = ArrayDisplay(stations)
+
+        attrs = [
+            "x",
+            "y",
+            "z",
+            "r",
+            "axis_unit_label",
+            "xlabel",
+            "ylabel",
+        ]
+
+        for attr in attrs:
+            assert hasattr(disp, attr)
+
+    def test_set_unit_auto_deg(self, mocker, mock_stations):
+        stations = mock_stations
+
+        stations.x *= 1e6
+        stations.y *= 1e6
+        stations.z *= 1e6
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        disp = ArrayDisplay(stations, unit="auto")
+
+        assert disp.axis_unit_label == "deg"
+
+    def test_set_unit_auto_km(self, mocker, mock_stations):
+        stations = mock_stations
+
+        stations.x *= 1e3
+        stations.y *= 1e3
+        stations.z *= 1e3
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        disp = ArrayDisplay(stations, unit="auto")
+
+        assert disp.axis_unit_label == "km"
+
+    def test_set_unit_auto_m(self, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        disp = ArrayDisplay(stations, unit="auto")
+
+        assert disp.axis_unit_label == "m"
+
+    def test_set_unit_km(self, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        disp = ArrayDisplay(stations, unit="km")
+
+        assert disp.unit == "km"
+        assert disp.axis_unit_label == "km"
+
+    def test_set_unit_deg(self, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        disp = ArrayDisplay(stations, unit="deg")
+
+        assert disp.unit == "deg"
+        assert disp.axis_unit_label == "deg"
+
+    def test_set_unit_m(self, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        disp = ArrayDisplay(stations, unit="m")
+
+        assert disp.unit == "m"
+        assert disp.axis_unit_label == "m"
+
+    def test_set_unit_raises(self, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+        mocker.patch.object(ArrayDisplay, "_add_antennas")
+
+        wrong_unit = "Jy"
+
+        with pytest.raises(ValueError, match=f"unit {wrong_unit!r} is unknown"):
+            ArrayDisplay(stations, unit="Jy")
+
+    @pytest.mark.parametrize("marker_type", ["fixed", "diameter"])
+    def test_add_antennas(self, marker_type, mocker, mock_stations):
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+
+        disp = ArrayDisplay(stations, marker_type=marker_type)
+
+        assert disp.marker_type == marker_type
+        assert hasattr(disp, "marker_sizes")
+        assert disp.marker_sizes[0] == disp.marker_size
+        assert hasattr(disp, "antennas")
+        assert isinstance(disp.antennas, PathCollection)
+
+    @pytest.mark.parametrize("marker_color", ["blue", None])
+    def test_add_antennas_color(self, marker_color, mocker, mock_stations):
+        import cmasher as cmr
+        from cycler import cycler
+
+        colors = cmr.take_cmap_colors("tab10", None, return_fmt="hex")
+        plt.rc("axes", prop_cycle=cycler(color=colors))
+
+        stations = mock_stations
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+
+        disp = ArrayDisplay(stations, marker_color=marker_color)
+
+        # If None, color is selected from mpl prop_cycle
+        if marker_color is None:
+            marker_color = "#1F77B4"
+
+        assert disp.marker_color == marker_color
+
+    @pytest.mark.parametrize("diam", [np.nan, -1])
+    def test_dish_marker_sizes_raises_non_finite(self, diam, mocker, mock_stations):
+        stations = mock_stations
+        stations.diam = np.full_like(stations.diam, diam)
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+
+        with pytest.raises(
+            ValueError, match="station diameters must be finite and > 0"
+        ):
+            ArrayDisplay(stations, marker_type="diameter")
+
+    def test_dish_marker_sizes_raises_scale(self, mocker, mock_stations):
+        stations = mock_stations
+        stations.diam = np.arange(len(stations.diam)) + 1
+
+        mocker.patch.object(ArrayDisplay, "_add_radial_grid")
+
+        with pytest.raises(
+            ValueError, match="chosen diameter_scale creates non-positive marker sizes"
+        ):
+            ArrayDisplay(stations, marker_type="diameter", diameter_scale=-1)
+
+    def test_add_radial_grid(self, mock_locations):
+        loc = mock_locations
+
+        class MockArrayDisplay:
+            _add_radial_grid = ArrayDisplay._add_radial_grid
+
+            def __init__(self):
+
+                self.x = loc.x
+                self.y = loc.y
+
+                self.fig, self.axes = plt.subplots()
+
+            def _grid_step(self, val):
+                return 2.0
+
+        disp = MockArrayDisplay()
+        assert len(disp.axes.collections) == 0
+
+        disp._add_radial_grid(center=(0, 0), color="red", alpha=0.75, linewidth=3.0)
+        assert len(disp.axes.collections) == 1
+
+        collection = disp.axes.collections[0]
+
+        assert isinstance(collection, PatchCollection)
+        assert collection.get_alpha() == 0.75
+        assert collection.get_linewidth()[0] == 3.0  # ty:ignore[not-subscriptable]
+
+        paths = collection.get_paths()
+        assert len(paths) > 0
+
+        plt.close(disp.fig)
+
+    @pytest.mark.parametrize("step", [0.0, -1.0])
+    def test_add_radial_grid_step_invalid(self, step, mock_locations):
+        """Check that no grid is added when step is invalid"""
+        loc = mock_locations
+
+        class MockArrayDisplay:
+            _add_radial_grid = ArrayDisplay._add_radial_grid
+
+            def __init__(self):
+
+                self.x = loc.x
+                self.y = loc.y
+
+                self.fig, self.axes = plt.subplots()
+
+            def _grid_step(self, val):
+                return -step  # negative value should be invalid
+
+        disp = MockArrayDisplay()
+        assert len(disp.axes.collections) == 0
+
+        disp._add_radial_grid(center=(0, 0), color="red", alpha=0.75, linewidth=3.0)
+        assert len(disp.axes.collections) == 0
+
+        plt.close(disp.fig)

--- a/tests/layouts/test_layouts.py
+++ b/tests/layouts/test_layouts.py
@@ -8,25 +8,6 @@ from pyvisgen.layouts import Stations, get_array_layout, get_array_names
 
 
 class TestStations:
-    @pytest.fixture
-    def params(self) -> dict:
-        rng = np.random.default_rng()
-
-        params = dict(
-            st_name=np.arange(10),
-            st_num=np.arange(10),
-            x=rng.uniform(size=(10)),
-            y=rng.uniform(size=(10)),
-            z=rng.uniform(size=(10)),
-            diam=np.full(shape=(10), fill_value=5),
-            el_low=np.full(shape=(10), fill_value=15),
-            el_high=np.full(shape=(10), fill_value=85),
-            altitude=rng.uniform(1e2, 8e3, size=(10)),
-            sefd=np.full(shape=(10), fill_value=100),
-        )
-
-        return params
-
     def test_stations_instantiation(self, params: dict) -> None:
         # should not raise an exception
         Stations(**params)
@@ -82,7 +63,7 @@ class TestGetArrayLayout:
         assert isinstance(stations, pd.DataFrame)
         pd.testing.assert_frame_equal(stations, df)
 
-    def test_vla_abs_pos(self, mocker, monkeypatch):
+    def test_vla_abs_pos(self, mocker):
         mock_loc = mocker.MagicMock()
         mock_loc.value = np.ones(shape=(27))
 

--- a/tests/layouts/test_layouts.py
+++ b/tests/layouts/test_layouts.py
@@ -37,6 +37,14 @@ class TestStations:
         for item, param in zip(stations[0], params):
             assert item == param[0]
 
+    def test_peek(self, mocker, params) -> None:
+        stations = Stations(**params)
+
+        mock_array_display = mocker.patch("pyvisgen.layouts.layouts.ArrayDisplay")
+        stations.peek()
+
+        assert mock_array_display.called
+
 
 class TestGetArrayLayout:
     def test_array_layout_str(self) -> None:

--- a/tests/layouts/test_layouts.py
+++ b/tests/layouts/test_layouts.py
@@ -13,6 +13,7 @@ class TestStations:
         rng = np.random.default_rng()
 
         params = dict(
+            st_name=np.arange(10),
             st_num=np.arange(10),
             x=rng.uniform(size=(10)),
             y=rng.uniform(size=(10)),

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,13 @@
+import pytest
+
+from pyvisgen.exceptions import OptionalDependencyMissing
+
+
+def test_optional_dependency_missing_exception():
+    opt_dep = "plot"
+
+    with pytest.raises(
+        OptionalDependencyMissing,
+        match=rf"you need to install pyvisgen with the \[{opt_dep}\]",
+    ):
+        raise OptionalDependencyMissing(opt_dep)

--- a/uv.lock
+++ b/uv.lock
@@ -362,6 +362,20 @@ wheels = [
 ]
 
 [[package]]
+name = "cmasher"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorspacious" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/ca/39152b506133881be74bd46cced27ec10d9bbc85db5bdfc22c8f8e4011f9/cmasher-1.9.2.tar.gz", hash = "sha256:6c90c2cec87146e3210d3e7f2321fceee38ac7d87c136cd0de25160a14f57ff5", size = 520860, upload-time = "2024-11-19T11:17:02.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/d2/6fcb93a60777fef7662d84ba60846d2dee9b6b70b4a62472515110f79cee/cmasher-1.9.2-py3-none-any.whl", hash = "sha256:2fe45fde06051050dda5c023a527ba9066ca21f161c793f22839a6ebe6e4bbbb", size = 506496, upload-time = "2024-11-19T11:16:58.549Z" },
+]
+
+[[package]]
 name = "codecarbon"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -393,6 +407,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorspacious"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/e4/aa41ae14c5c061205715006c8834496d86ec7500f1edda5981f0f0190cc6/colorspacious-1.1.2.tar.gz", hash = "sha256:5e9072e8cdca889dac445c35c9362a22ccf758e97b00b79ff0d5a7ba3e11b618", size = 688573, upload-time = "2018-04-08T04:27:30.83Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/a1/318b9aeca7b9856410ededa4f52d6f82174d1a41e64bdd70d951e532675a/colorspacious-1.1.2-py2.py3-none-any.whl", hash = "sha256:c78befa603cea5dccb332464e7dd29e96469eebf6cd5133029153d1e69e3fd6f", size = 37735, upload-time = "2018-04-08T04:27:22.143Z" },
 ]
 
 [[package]]
@@ -2730,6 +2756,7 @@ webdataset = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "cmasher" },
     { name = "coverage" },
     { name = "graphviz" },
     { name = "h5py" },
@@ -2783,6 +2810,7 @@ docs = [
     { name = "sphinxcontrib-bibtex" },
 ]
 tests = [
+    { name = "cmasher" },
     { name = "coverage" },
     { name = "h5py" },
     { name = "pytest" },
@@ -2826,6 +2854,7 @@ provides-extras = ["all", "codecarbon", "plot", "tutorials", "webdataset"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cmasher", specifier = ">=1.9.2" },
     { name = "coverage", specifier = "!=6.3.0" },
     { name = "graphviz" },
     { name = "h5py" },
@@ -2879,6 +2908,7 @@ docs = [
     { name = "sphinxcontrib-bibtex" },
 ]
 tests = [
+    { name = "cmasher", specifier = ">=1.9.2" },
     { name = "coverage", specifier = "!=6.3.0" },
     { name = "h5py" },
     { name = "pytest", specifier = ">=7.0" },


### PR DESCRIPTION
Add ArrayDisplay class that allows to plot the telescope/antenna locations from a pyvisgen Stations object. Stations now also includes a peek method, that calls ArrayDisplay on itself.

### Examples
```python
from pyvisgen.layouts import get_array_layout

arr = get_array_layout("lofar_lotss")
disp = arr.peek(zoomed=True)
```
<img width="440" height="428" alt="image" src="https://github.com/user-attachments/assets/5cdcf6ad-809d-43b0-ad38-0e8e08563645" />

ArrayDisplay has a builtin label method:
```python
arr = get_array_layout("vlba")
disp = arr.peek(zoomed=True)
disp.add_labels()
```
<img width="440" height="428" alt="image" src="https://github.com/user-attachments/assets/05159aa9-fb42-4a87-9d73-cadaada1a57d" />

Labels can be changed from names to ids:
```python
arr = get_array_layout("alma_dsharp")
disp = arr.peek(zoomed=True)
disp.add_labels(ids=True)
```
<img width="434" height="424" alt="image" src="https://github.com/user-attachments/assets/4b296b60-c978-4c14-93ce-055552f58f3f" />
